### PR TITLE
Add streaming decoder API for DSS/DS2 and route batch decode through it

### DIFF
--- a/dss-codec/src/codec/ds2_qp.rs
+++ b/dss-codec/src/codec/ds2_qp.rs
@@ -60,21 +60,25 @@ impl Ds2QpDecoder {
         let mut all_samples = Vec::with_capacity(total_frames * SAMPLES_PER_FRAME);
 
         for _ in 0..total_frames {
-            let samples = self.decode_frame_from_reader(&mut reader);
+            let mut frame = [0u8; 56];
+            for word in 0..28 {
+                let value = reader.read_bits(16) as u16;
+                frame[word * 2] = value as u8;
+                frame[word * 2 + 1] = (value >> 8) as u8;
+            }
+            let samples = self.decode_frame(&frame);
             all_samples.extend_from_slice(&samples);
         }
 
-        // Apply de-emphasis: y[n] = x[n] + 0.1*y[n-1]
-        let alpha = 0.1;
-        if !all_samples.is_empty() {
-            all_samples[0] += alpha * self.deemph_state;
-            for i in 1..all_samples.len() {
-                all_samples[i] += alpha * all_samples[i - 1];
-            }
-            self.deemph_state = *all_samples.last().unwrap();
-        }
-
         all_samples
+    }
+
+    /// Decode a single QP frame from its 56-byte payload.
+    pub fn decode_frame(&mut self, frame_bytes: &[u8]) -> Vec<f64> {
+        let mut reader = BitstreamReader::new(frame_bytes);
+        let mut samples = self.decode_frame_from_reader(&mut reader);
+        self.apply_deemphasis(&mut samples);
+        samples
     }
 
     fn decode_frame_from_reader(&mut self, reader: &mut BitstreamReader) -> Vec<f64> {
@@ -131,8 +135,7 @@ impl Ds2QpDecoder {
 
             // Fixed codebook excitation
             let gc = QP_EXCITATION_GAIN[*gain_idx];
-            let positions =
-                decode_combinatorial_index(*cb_idx, SUBFRAME_SIZE, EXCITATION_PULSES);
+            let positions = decode_combinatorial_index(*cb_idx, SUBFRAME_SIZE, EXCITATION_PULSES);
             let mut fixed_exc = [0.0f64; SUBFRAME_SIZE];
             for (pi, &pos) in positions.iter().enumerate() {
                 if pos < SUBFRAME_SIZE {
@@ -159,5 +162,16 @@ impl Ds2QpDecoder {
         }
 
         all_output
+    }
+
+    fn apply_deemphasis(&mut self, samples: &mut [f64]) {
+        let alpha = 0.1;
+        if !samples.is_empty() {
+            samples[0] += alpha * self.deemph_state;
+            for i in 1..samples.len() {
+                samples[i] += alpha * samples[i - 1];
+            }
+            self.deemph_state = *samples.last().unwrap();
+        }
     }
 }

--- a/dss-codec/src/demux/ds2.rs
+++ b/dss-codec/src/demux/ds2.rs
@@ -3,11 +3,11 @@
 /// SP mode (0-1): byte-swap demuxing, returns list of 42-byte packets.
 /// QP mode (6-7): continuous bitstream, returns raw byte stream + frame count.
 use crate::error::{DecodeError, Result};
-
 const DS2_HEADER_SIZE: usize = 0x600;
 const DS2_BLOCK_SIZE: usize = 512;
 const DS2_BLOCK_HEADER_SIZE: usize = 6;
 const DSS_SP_PACKET_SIZE: usize = 42;
+const DS2_QP_FRAME_SIZE: usize = 56;
 
 /// Demux a DS2 file.
 /// Returns (frame_data, total_frames, is_qp).
@@ -31,9 +31,8 @@ pub fn demux_ds2(data: &[u8]) -> Result<DemuxedDs2> {
         let mut stream = Vec::new();
         for bi in 0..num_blocks {
             let bstart = DS2_HEADER_SIZE + bi * DS2_BLOCK_SIZE;
-            stream.extend_from_slice(
-                &data[bstart + DS2_BLOCK_HEADER_SIZE..bstart + DS2_BLOCK_SIZE],
-            );
+            stream
+                .extend_from_slice(&data[bstart + DS2_BLOCK_HEADER_SIZE..bstart + DS2_BLOCK_SIZE]);
         }
         Ok(DemuxedDs2::Qp {
             stream,
@@ -44,9 +43,8 @@ pub fn demux_ds2(data: &[u8]) -> Result<DemuxedDs2> {
         let mut stream = Vec::new();
         for bi in 0..num_blocks {
             let bstart = DS2_HEADER_SIZE + bi * DS2_BLOCK_SIZE;
-            stream.extend_from_slice(
-                &data[bstart + DS2_BLOCK_HEADER_SIZE..bstart + DS2_BLOCK_SIZE],
-            );
+            stream
+                .extend_from_slice(&data[bstart + DS2_BLOCK_HEADER_SIZE..bstart + DS2_BLOCK_SIZE]);
         }
 
         let mut swap = ((data[DS2_HEADER_SIZE] >> 7) & 1) as usize;
@@ -95,4 +93,315 @@ pub enum DemuxedDs2 {
         stream: Vec<u8>,
         total_frames: usize,
     },
+}
+
+pub(crate) struct Ds2SpStreamDemuxer {
+    header_complete: bool,
+    block_buf: Vec<u8>,
+    stream_buf: Vec<u8>,
+    pending_frames: usize,
+    swap: usize,
+    swap_byte: u8,
+    have_initial_swap: bool,
+}
+
+impl Ds2SpStreamDemuxer {
+    pub(crate) fn new() -> Self {
+        Self {
+            header_complete: false,
+            block_buf: Vec::new(),
+            stream_buf: Vec::new(),
+            pending_frames: 0,
+            swap: 0,
+            swap_byte: 0,
+            have_initial_swap: false,
+        }
+    }
+
+    pub(crate) fn push(&mut self, data: &[u8]) -> Result<Vec<Vec<u8>>> {
+        let mut frames = Vec::new();
+        let mut offset = 0;
+
+        if !self.header_complete {
+            let needed = DS2_HEADER_SIZE.saturating_sub(self.block_buf.len());
+            let take = needed.min(data.len());
+            self.block_buf.extend_from_slice(&data[..take]);
+            offset += take;
+            if self.block_buf.len() < DS2_HEADER_SIZE {
+                return Ok(frames);
+            }
+            self.header_complete = true;
+            self.block_buf.clear();
+        }
+
+        self.block_buf.extend_from_slice(&data[offset..]);
+        while self.block_buf.len() >= DS2_BLOCK_SIZE {
+            let block: Vec<u8> = self.block_buf.drain(..DS2_BLOCK_SIZE).collect();
+            self.process_block(&block, &mut frames);
+        }
+
+        Ok(frames)
+    }
+
+    pub(crate) fn finish(&mut self) -> Result<Vec<Vec<u8>>> {
+        if !self.header_complete {
+            if self.block_buf.is_empty() {
+                return Ok(Vec::new());
+            }
+            return Err(DecodeError::Truncated("DS2 header".to_string()));
+        }
+        if !self.block_buf.is_empty() {
+            return Err(DecodeError::Truncated("DS2 block".to_string()));
+        }
+        if self.pending_frames > 0 {
+            return Err(DecodeError::Truncated("DS2 SP frame".to_string()));
+        }
+        Ok(Vec::new())
+    }
+
+    pub(crate) fn finish_lenient(&mut self) -> Result<Vec<Vec<u8>>> {
+        if !self.header_complete {
+            if self.block_buf.is_empty() {
+                return Ok(Vec::new());
+            }
+            return Err(DecodeError::Truncated("DS2 header".to_string()));
+        }
+
+        self.block_buf.clear();
+
+        let mut frames = Vec::with_capacity(self.pending_frames);
+        while self.pending_frames > 0 {
+            let needed = if self.swap != 0 {
+                40
+            } else {
+                DSS_SP_PACKET_SIZE
+            };
+            frames.push(self.extract_sp_packet_padded(needed));
+            self.pending_frames -= 1;
+        }
+
+        Ok(frames)
+    }
+
+    fn process_block(&mut self, block: &[u8], frames: &mut Vec<Vec<u8>>) {
+        if !self.have_initial_swap {
+            self.swap = ((block[0] >> 7) & 1) as usize;
+            self.have_initial_swap = true;
+        }
+        self.pending_frames += block[2] as usize;
+        self.stream_buf
+            .extend_from_slice(&block[DS2_BLOCK_HEADER_SIZE..DS2_BLOCK_SIZE]);
+
+        while self.pending_frames > 0 {
+            let needed = if self.swap != 0 {
+                40
+            } else {
+                DSS_SP_PACKET_SIZE
+            };
+            if self.stream_buf.len() < needed {
+                break;
+            }
+            frames.push(self.extract_sp_packet(needed));
+            self.pending_frames -= 1;
+        }
+    }
+
+    fn extract_sp_packet(&mut self, read_size: usize) -> Vec<u8> {
+        let mut pkt = [0u8; DSS_SP_PACKET_SIZE + 1];
+        let chunk: Vec<u8> = self.stream_buf.drain(..read_size).collect();
+        self.fill_sp_packet(&mut pkt, &chunk);
+        pkt[..DSS_SP_PACKET_SIZE].to_vec()
+    }
+
+    fn extract_sp_packet_padded(&mut self, read_size: usize) -> Vec<u8> {
+        let take = read_size.min(self.stream_buf.len());
+        let chunk: Vec<u8> = self.stream_buf.drain(..take).collect();
+        let mut pkt = [0u8; DSS_SP_PACKET_SIZE + 1];
+        self.fill_sp_packet(&mut pkt, &chunk);
+        pkt[..DSS_SP_PACKET_SIZE].to_vec()
+    }
+
+    fn fill_sp_packet(&mut self, pkt: &mut [u8; DSS_SP_PACKET_SIZE + 1], chunk: &[u8]) {
+        if self.swap != 0 {
+            pkt[3..3 + chunk.len()].copy_from_slice(chunk);
+            for i in (0..DSS_SP_PACKET_SIZE - 2).step_by(2) {
+                pkt[i] = pkt[i + 4];
+            }
+            pkt[DSS_SP_PACKET_SIZE] = 0;
+            pkt[1] = self.swap_byte;
+        } else {
+            pkt[..chunk.len()].copy_from_slice(chunk);
+            self.swap_byte = pkt[DSS_SP_PACKET_SIZE - 2];
+        }
+        pkt[DSS_SP_PACKET_SIZE - 2] = 0;
+        self.swap ^= 1;
+    }
+}
+
+pub(crate) struct Ds2QpStreamDemuxer {
+    header_complete: bool,
+    block_buf: Vec<u8>,
+    stream_buf: Vec<u8>,
+    pending_frames: usize,
+}
+
+impl Ds2QpStreamDemuxer {
+    pub(crate) fn new() -> Self {
+        Self {
+            header_complete: false,
+            block_buf: Vec::new(),
+            stream_buf: Vec::new(),
+            pending_frames: 0,
+        }
+    }
+
+    pub(crate) fn push(&mut self, data: &[u8]) -> Result<Vec<Vec<u8>>> {
+        let mut frames = Vec::new();
+        let mut offset = 0;
+
+        if !self.header_complete {
+            let needed = DS2_HEADER_SIZE.saturating_sub(self.block_buf.len());
+            let take = needed.min(data.len());
+            self.block_buf.extend_from_slice(&data[..take]);
+            offset += take;
+            if self.block_buf.len() < DS2_HEADER_SIZE {
+                return Ok(frames);
+            }
+            self.header_complete = true;
+            self.block_buf.clear();
+        }
+
+        self.block_buf.extend_from_slice(&data[offset..]);
+        while self.block_buf.len() >= DS2_BLOCK_SIZE {
+            let block: Vec<u8> = self.block_buf.drain(..DS2_BLOCK_SIZE).collect();
+            self.process_block(&block, &mut frames);
+        }
+
+        Ok(frames)
+    }
+
+    pub(crate) fn finish(&mut self) -> Result<Vec<Vec<u8>>> {
+        if !self.header_complete {
+            if self.block_buf.is_empty() {
+                return Ok(Vec::new());
+            }
+            return Err(DecodeError::Truncated("DS2 header".to_string()));
+        }
+        if !self.block_buf.is_empty() {
+            return Err(DecodeError::Truncated("DS2 block".to_string()));
+        }
+        if self.pending_frames > 0 {
+            return Err(DecodeError::Truncated("DS2 QP frame".to_string()));
+        }
+        Ok(Vec::new())
+    }
+
+    pub(crate) fn finish_lenient(&mut self) -> Result<Vec<Vec<u8>>> {
+        if !self.header_complete {
+            if self.block_buf.is_empty() {
+                return Ok(Vec::new());
+            }
+            return Err(DecodeError::Truncated("DS2 header".to_string()));
+        }
+
+        self.block_buf.clear();
+
+        let mut frames = Vec::with_capacity(self.pending_frames);
+        while self.pending_frames > 0 {
+            let take = DS2_QP_FRAME_SIZE.min(self.stream_buf.len());
+            let mut frame = vec![0u8; DS2_QP_FRAME_SIZE];
+            let chunk: Vec<u8> = self.stream_buf.drain(..take).collect();
+            frame[..chunk.len()].copy_from_slice(&chunk);
+            frames.push(frame);
+            self.pending_frames -= 1;
+        }
+
+        Ok(frames)
+    }
+
+    fn process_block(&mut self, block: &[u8], frames: &mut Vec<Vec<u8>>) {
+        self.pending_frames += block[2] as usize;
+        self.stream_buf
+            .extend_from_slice(&block[DS2_BLOCK_HEADER_SIZE..DS2_BLOCK_SIZE]);
+
+        while self.pending_frames > 0 && self.stream_buf.len() >= DS2_QP_FRAME_SIZE {
+            let frame: Vec<u8> = self.stream_buf.drain(..DS2_QP_FRAME_SIZE).collect();
+            frames.push(frame);
+            self.pending_frames -= 1;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_ds2_file(mode: u8, frame_count: u8, payload_pattern: u8) -> Vec<u8> {
+        let mut data = vec![0u8; DS2_HEADER_SIZE];
+        data[..4].copy_from_slice(b"\x03ds2");
+
+        let mut block = [0u8; DS2_BLOCK_SIZE];
+        block[2] = frame_count;
+        block[4] = mode;
+        for (i, byte) in block[DS2_BLOCK_HEADER_SIZE..].iter_mut().enumerate() {
+            *byte = payload_pattern.wrapping_add(i as u8);
+        }
+
+        data.extend_from_slice(&block);
+        data
+    }
+
+    #[test]
+    fn test_ds2_sp_stream_demux_matches_batch() {
+        let data = make_ds2_file(0, 4, 0x10);
+        let expected = match demux_ds2(&data).unwrap() {
+            DemuxedDs2::Sp { packets, .. } => packets,
+            _ => panic!("expected DS2 SP packets"),
+        };
+
+        let mut demuxer = Ds2SpStreamDemuxer::new();
+        let mut actual = Vec::new();
+        for chunk in data.chunks(137) {
+            actual.extend(demuxer.push(chunk).unwrap());
+        }
+        actual.extend(demuxer.finish().unwrap());
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_ds2_qp_stream_demux_matches_batch() {
+        let data = make_ds2_file(6, 3, 0x40);
+        let expected = match demux_ds2(&data).unwrap() {
+            DemuxedDs2::Qp {
+                stream,
+                total_frames,
+            } => stream[..total_frames * DS2_QP_FRAME_SIZE]
+                .chunks(DS2_QP_FRAME_SIZE)
+                .map(|chunk| chunk.to_vec())
+                .collect::<Vec<_>>(),
+            _ => panic!("expected DS2 QP stream"),
+        };
+
+        let mut demuxer = Ds2QpStreamDemuxer::new();
+        let mut actual = Vec::new();
+        for chunk in data.chunks(113) {
+            actual.extend(demuxer.push(chunk).unwrap());
+        }
+        actual.extend(demuxer.finish().unwrap());
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_ds2_qp_stream_demux_truncated_frame() {
+        let data = make_ds2_file(6, 10, 0x55);
+        let mut demuxer = Ds2QpStreamDemuxer::new();
+        for chunk in data.chunks(97) {
+            let _ = demuxer.push(chunk).unwrap();
+        }
+
+        let err = demuxer.finish().unwrap_err();
+        assert!(matches!(err, DecodeError::Truncated(_)));
+    }
 }

--- a/dss-codec/src/demux/dss.rs
+++ b/dss-codec/src/demux/dss.rs
@@ -3,6 +3,7 @@
 /// Handles empty blocks (frame_count=0) by only including continuation bytes
 /// from empty block payloads, and resetting swap state at block group boundaries.
 use crate::error::{DecodeError, Result};
+use std::collections::VecDeque;
 
 const DSS_BLOCK_SIZE: usize = 512;
 const DSS_BLOCK_HEADER_SIZE: usize = 6;
@@ -106,4 +107,307 @@ pub fn demux_dss(data: &[u8]) -> Result<(Vec<Vec<u8>>, usize)> {
     }
 
     Ok((frame_packets, total_frames))
+}
+
+pub(crate) struct DssSpStreamDemuxer {
+    header_size: usize,
+    header_complete: bool,
+    block_buf: Vec<u8>,
+    stream_buf: Vec<u8>,
+    stream_pos: usize,
+    pending_frames: usize,
+    swap: usize,
+    swap_byte: u8,
+    have_initial_swap: bool,
+    stream_end_pos: usize,
+    pending_reset_positions: Vec<usize>,
+    scheduled_resets: VecDeque<(usize, usize)>,
+}
+
+impl DssSpStreamDemuxer {
+    pub(crate) fn new(version: u8) -> Self {
+        Self {
+            header_size: version as usize * DSS_BLOCK_SIZE,
+            header_complete: false,
+            block_buf: Vec::new(),
+            stream_buf: Vec::new(),
+            stream_pos: 0,
+            pending_frames: 0,
+            swap: 0,
+            swap_byte: 0,
+            have_initial_swap: false,
+            stream_end_pos: 0,
+            pending_reset_positions: Vec::new(),
+            scheduled_resets: VecDeque::new(),
+        }
+    }
+
+    pub(crate) fn push(&mut self, data: &[u8]) -> Result<Vec<Vec<u8>>> {
+        let mut frames = Vec::new();
+        let mut offset = 0;
+
+        if !self.header_complete {
+            let needed = self.header_size.saturating_sub(self.block_buf.len());
+            let take = needed.min(data.len());
+            self.block_buf.extend_from_slice(&data[..take]);
+            offset += take;
+            if self.block_buf.len() < self.header_size {
+                return Ok(frames);
+            }
+            self.header_complete = true;
+            self.block_buf.clear();
+        }
+
+        self.block_buf.extend_from_slice(&data[offset..]);
+        while self.block_buf.len() >= DSS_BLOCK_SIZE {
+            let block: Vec<u8> = self.block_buf.drain(..DSS_BLOCK_SIZE).collect();
+            self.process_block(&block, &mut frames);
+        }
+
+        Ok(frames)
+    }
+
+    pub(crate) fn finish(&mut self) -> Result<Vec<Vec<u8>>> {
+        if !self.header_complete {
+            if self.block_buf.is_empty() {
+                return Ok(Vec::new());
+            }
+            return Err(DecodeError::Truncated("DSS header".to_string()));
+        }
+        if !self.block_buf.is_empty() {
+            return Err(DecodeError::Truncated("DSS block".to_string()));
+        }
+        if self.pending_frames > 0 {
+            return Err(DecodeError::Truncated("DSS SP frame".to_string()));
+        }
+        Ok(Vec::new())
+    }
+
+    pub(crate) fn finish_lenient(&mut self) -> Result<Vec<Vec<u8>>> {
+        if !self.header_complete {
+            if self.block_buf.is_empty() {
+                return Ok(Vec::new());
+            }
+            return Err(DecodeError::Truncated("DSS header".to_string()));
+        }
+
+        self.block_buf.clear();
+
+        let mut frames = Vec::with_capacity(self.pending_frames);
+        while self.pending_frames > 0 {
+            while let Some(&(reset_pos, new_swap)) = self.scheduled_resets.front() {
+                if self.stream_pos != reset_pos {
+                    break;
+                }
+                self.swap = new_swap;
+                self.swap_byte = 0;
+                self.scheduled_resets.pop_front();
+            }
+
+            let needed = if self.swap != 0 { 40 } else { DSS_SP_FRAME_SIZE };
+            frames.push(self.extract_packet_padded(needed));
+            self.pending_frames -= 1;
+            self.compact_stream();
+        }
+
+        Ok(frames)
+    }
+
+    fn process_block(&mut self, block: &[u8], frames: &mut Vec<Vec<u8>>) {
+        let byte0 = block[0];
+        let byte1 = block[1] as usize;
+        let frame_count = block[2] as usize;
+        let blk_swap = ((byte0 >> 7) & 1) as usize;
+        let cont_size = (2 * byte1 + 2 * blk_swap).saturating_sub(DSS_BLOCK_HEADER_SIZE);
+        let payload = &block[DSS_BLOCK_HEADER_SIZE..];
+
+        if !self.have_initial_swap {
+            self.swap = blk_swap;
+            self.have_initial_swap = true;
+        }
+
+        if frame_count == 0 {
+            let cs = cont_size.min(payload.len());
+            self.stream_buf.extend_from_slice(&payload[..cs]);
+            self.stream_end_pos += cs;
+            self.pending_reset_positions.push(self.stream_end_pos);
+        } else {
+            if !self.pending_reset_positions.is_empty() {
+                for pos in self.pending_reset_positions.drain(..) {
+                    self.scheduled_resets.push_back((pos, blk_swap));
+                }
+            }
+            self.stream_buf.extend_from_slice(payload);
+            self.stream_end_pos += payload.len();
+            self.pending_frames += frame_count;
+        }
+
+        self.emit_available_frames(frames);
+    }
+
+    fn emit_available_frames(&mut self, frames: &mut Vec<Vec<u8>>) {
+        while self.pending_frames > 0 {
+            while let Some(&(reset_pos, new_swap)) = self.scheduled_resets.front() {
+                if self.stream_pos != reset_pos {
+                    break;
+                }
+                self.swap = new_swap;
+                self.swap_byte = 0;
+                self.scheduled_resets.pop_front();
+            }
+
+            let needed = if self.swap != 0 {
+                40
+            } else {
+                DSS_SP_FRAME_SIZE
+            };
+            if self.available_stream() < needed {
+                break;
+            }
+
+            frames.push(self.extract_packet(needed));
+            self.pending_frames -= 1;
+            self.compact_stream();
+        }
+    }
+
+    fn extract_packet(&mut self, read_size: usize) -> Vec<u8> {
+        let mut pkt = [0u8; DSS_SP_FRAME_SIZE + 1];
+        let end = self.stream_pos + read_size;
+        let chunk = self.stream_buf[self.stream_pos..end].to_vec();
+        self.fill_packet(&mut pkt, chunk);
+        self.stream_pos = end;
+        pkt[..DSS_SP_FRAME_SIZE].to_vec()
+    }
+
+    fn extract_packet_padded(&mut self, read_size: usize) -> Vec<u8> {
+        let take = read_size.min(self.available_stream());
+        let end = self.stream_pos + take;
+        let chunk = self.stream_buf[self.stream_pos..end].to_vec();
+        let mut pkt = [0u8; DSS_SP_FRAME_SIZE + 1];
+        self.fill_packet(&mut pkt, chunk);
+        self.stream_pos = end;
+        pkt[..DSS_SP_FRAME_SIZE].to_vec()
+    }
+
+    fn fill_packet(&mut self, pkt: &mut [u8; DSS_SP_FRAME_SIZE + 1], chunk: Vec<u8>) {
+        if self.swap != 0 {
+            pkt[3..3 + chunk.len()].copy_from_slice(&chunk);
+            for i in (0..DSS_SP_FRAME_SIZE - 2).step_by(2) {
+                pkt[i] = pkt[i + 4];
+            }
+            pkt[DSS_SP_FRAME_SIZE] = 0;
+            pkt[1] = self.swap_byte;
+        } else {
+            pkt[..chunk.len()].copy_from_slice(&chunk);
+            self.swap_byte = pkt[DSS_SP_FRAME_SIZE - 2];
+        }
+        pkt[DSS_SP_FRAME_SIZE - 2] = 0;
+        self.swap ^= 1;
+    }
+
+    fn available_stream(&self) -> usize {
+        self.stream_buf.len().saturating_sub(self.stream_pos)
+    }
+
+    fn compact_stream(&mut self) {
+        if self.stream_pos == 0 {
+            return;
+        }
+        if self.stream_pos >= self.stream_buf.len() {
+            self.stream_buf.clear();
+            self.stream_pos = 0;
+            return;
+        }
+        self.stream_buf.drain(..self.stream_pos);
+        let consumed = self.stream_pos;
+        self.stream_pos = 0;
+        for pos in &mut self.pending_reset_positions {
+            *pos = pos.saturating_sub(consumed);
+        }
+        for (pos, _) in &mut self.scheduled_resets {
+            *pos = pos.saturating_sub(consumed);
+        }
+        self.stream_end_pos = self.stream_end_pos.saturating_sub(consumed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_dss_block(
+        swap: u8,
+        byte1: u8,
+        frame_count: u8,
+        payload_pattern: u8,
+    ) -> [u8; DSS_BLOCK_SIZE] {
+        let mut block = [0u8; DSS_BLOCK_SIZE];
+        block[0] = swap << 7;
+        block[1] = byte1;
+        block[2] = frame_count;
+        for (i, byte) in block[DSS_BLOCK_HEADER_SIZE..].iter_mut().enumerate() {
+            *byte = payload_pattern.wrapping_add(i as u8);
+        }
+        block
+    }
+
+    fn collect_frames(
+        demuxer: &mut DssSpStreamDemuxer,
+        data: &[u8],
+        chunk_size: usize,
+    ) -> Vec<Vec<u8>> {
+        let mut frames = Vec::new();
+        for chunk in data.chunks(chunk_size) {
+            frames.extend(demuxer.push(chunk).unwrap());
+        }
+        frames.extend(demuxer.finish().unwrap());
+        frames
+    }
+
+    #[test]
+    fn test_dss_stream_demux_matches_batch() {
+        let mut data = vec![0u8; 2 * DSS_BLOCK_SIZE];
+        data[0] = 2;
+        data[1..4].copy_from_slice(b"dss");
+        data.extend_from_slice(&make_dss_block(0, 0, 3, 0x20));
+
+        let (expected, _) = demux_dss(&data).unwrap();
+        let mut demuxer = DssSpStreamDemuxer::new(2);
+        let actual = collect_frames(&mut demuxer, &data, 149);
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_dss_stream_demux_empty_block_reset_matches_batch() {
+        let mut data = vec![0u8; 2 * DSS_BLOCK_SIZE];
+        data[0] = 2;
+        data[1..4].copy_from_slice(b"dss");
+        data.extend_from_slice(&make_dss_block(0, 0, 13, 0x10));
+        data.extend_from_slice(&make_dss_block(1, 17, 0, 0x80));
+        data.extend_from_slice(&make_dss_block(1, 0, 1, 0xC0));
+
+        let (expected, _) = demux_dss(&data).unwrap();
+        let mut demuxer = DssSpStreamDemuxer::new(2);
+        let actual = collect_frames(&mut demuxer, &data, 127);
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_dss_stream_demux_truncated_frame() {
+        let mut data = vec![0u8; 2 * DSS_BLOCK_SIZE];
+        data[0] = 2;
+        data[1..4].copy_from_slice(b"dss");
+        data.extend_from_slice(&make_dss_block(0, 0, 20, 0x30));
+
+        let mut demuxer = DssSpStreamDemuxer::new(2);
+        for chunk in data.chunks(211) {
+            let _ = demuxer.push(chunk).unwrap();
+        }
+
+        let err = demuxer.finish().unwrap_err();
+        assert!(matches!(err, DecodeError::Truncated(_)));
+    }
 }

--- a/dss-codec/src/error.rs
+++ b/dss-codec/src/error.rs
@@ -20,6 +20,12 @@ pub enum DecodeError {
     #[error("invalid frame data at frame {frame}: {detail}")]
     InvalidFrame { frame: usize, detail: String },
 
+    #[error("truncated data: {0}")]
+    Truncated(String),
+
+    #[error("streaming decoder is already finished")]
+    AlreadyFinished,
+
     #[error("WAV write error: {0}")]
     Wav(#[from] hound::Error),
 

--- a/dss-codec/src/lib.rs
+++ b/dss-codec/src/lib.rs
@@ -3,18 +3,15 @@ pub mod codec;
 pub mod demux;
 pub mod error;
 pub mod output;
+pub mod streaming;
 pub mod tables;
 
-use crate::codec::ds2_qp::Ds2QpDecoder;
-use crate::codec::ds2_sp::Ds2SpDecoder;
-use crate::codec::dss_sp::DssSpDecoder;
-use crate::demux::ds2::{demux_ds2, DemuxedDs2};
-use crate::demux::dss::demux_dss;
 use crate::demux::{detect_format, AudioFormat};
 use crate::error::{DecodeError, Result};
 use crate::output::resample::resample;
 use crate::output::wav::write_wav;
 use crate::output::OutputConfig;
+use crate::streaming::StreamingDecoder;
 
 use std::path::Path;
 
@@ -36,85 +33,154 @@ pub fn decode_file(path: &Path) -> Result<AudioBuffer> {
 
 /// Decode raw file bytes to an AudioBuffer.
 pub fn decode_to_buffer(data: &[u8]) -> Result<AudioBuffer> {
-    let format = detect_format(data)
+    let mut decoder = StreamingDecoder::new();
+    let mut samples = decoder.push(data)?;
+    samples.extend(decoder.finish_lenient()?);
+
+    let format = decoder
+        .format()
+        .or_else(|| detect_format(data))
         .ok_or_else(|| DecodeError::UnsupportedFormat(data.first().copied().unwrap_or(0)))?;
 
-    match format {
-        AudioFormat::DssSp => decode_dss_sp(data),
-        AudioFormat::Ds2Sp => decode_ds2_sp(data),
-        AudioFormat::Ds2Qp => decode_ds2_qp(data),
-    }
-}
-
-fn decode_dss_sp(data: &[u8]) -> Result<AudioBuffer> {
-    let (packets, total_frames) = demux_dss(data)?;
-    let mut decoder = DssSpDecoder::new();
-    let mut all_samples = Vec::with_capacity(total_frames * 264);
-
-    for pkt in &packets {
-        let frame_samples = decoder.decode_frame(pkt);
-        // Convert i16 to f64
-        all_samples.extend(frame_samples.iter().map(|&s| s as f64));
-    }
-
     Ok(AudioBuffer {
-        samples: all_samples,
-        native_rate: 11025,
-        format: AudioFormat::DssSp,
+        samples,
+        native_rate: format.native_sample_rate(),
+        format,
     })
 }
 
-fn decode_ds2_sp(data: &[u8]) -> Result<AudioBuffer> {
-    let demuxed = demux_ds2(data)?;
-    match demuxed {
-        DemuxedDs2::Sp {
-            packets,
-            total_frames,
-        } => {
-            let mut decoder = Ds2SpDecoder::new();
-            let mut all_samples = Vec::with_capacity(total_frames * 288);
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codec::ds2_sp::Ds2SpDecoder;
+    use crate::codec::dss_sp::DssSpDecoder;
+    use crate::codec::ds2_qp::Ds2QpDecoder;
+    use crate::demux::ds2::{demux_ds2, DemuxedDs2};
+    use crate::demux::dss::demux_dss;
 
-            for pkt in &packets {
-                let frame_samples = decoder.decode_frame(pkt);
-                all_samples.extend_from_slice(&frame_samples);
-            }
+    fn make_truncated_ds2_qp_file(frame_count: u8) -> Vec<u8> {
+        let mut data = vec![0u8; 0x600];
+        data[..4].copy_from_slice(b"\x03ds2");
 
-            Ok(AudioBuffer {
-                samples: all_samples,
-                native_rate: 12000,
-                format: AudioFormat::Ds2Sp,
-            })
+        let mut block = [0u8; 512];
+        block[2] = frame_count;
+        block[4] = 6;
+        for (i, byte) in block[6..].iter_mut().enumerate() {
+            *byte = (i as u8).wrapping_mul(3).wrapping_add(1);
         }
-        _ => Err(DecodeError::UnsupportedFormat(6)),
+
+        data.extend_from_slice(&block);
+        data
     }
-}
 
-fn decode_ds2_qp(data: &[u8]) -> Result<AudioBuffer> {
-    let demuxed = demux_ds2(data)?;
-    match demuxed {
-        DemuxedDs2::Qp {
-            stream,
-            total_frames,
-        } => {
-            let mut decoder = Ds2QpDecoder::new();
-            let all_samples = decoder.decode_all_frames(&stream, total_frames);
+    fn make_truncated_ds2_sp_file(frame_count: u8) -> Vec<u8> {
+        let mut data = vec![0u8; 0x600];
+        data[..4].copy_from_slice(b"\x03ds2");
 
-            Ok(AudioBuffer {
-                samples: all_samples,
-                native_rate: 16000,
-                format: AudioFormat::Ds2Qp,
-            })
+        let mut block = [0u8; 512];
+        block[2] = frame_count;
+        block[4] = 0;
+        for (i, byte) in block[6..].iter_mut().enumerate() {
+            *byte = (i as u8).wrapping_mul(5).wrapping_add(7);
         }
-        _ => Err(DecodeError::UnsupportedFormat(0)),
+
+        data.extend_from_slice(&block);
+        data
+    }
+
+    fn make_truncated_dss_sp_file(frame_count: u8) -> Vec<u8> {
+        let mut data = vec![0u8; 1024];
+        data[0] = 2;
+        data[1..4].copy_from_slice(b"dss");
+
+        let mut block = [0u8; 512];
+        block[2] = frame_count;
+        for (i, byte) in block[6..].iter_mut().enumerate() {
+            *byte = (i as u8).wrapping_mul(7).wrapping_add(3);
+        }
+
+        data.extend_from_slice(&block);
+        data
+    }
+
+    #[test]
+    fn test_decode_to_buffer_keeps_legacy_lenient_tail_handling_for_ds2_qp() {
+        let data = make_truncated_ds2_qp_file(10);
+
+        let expected = match demux_ds2(&data).unwrap() {
+            DemuxedDs2::Qp {
+                stream,
+                total_frames,
+            } => {
+                let mut decoder = Ds2QpDecoder::new();
+                decoder.decode_all_frames(&stream, total_frames)
+            }
+            _ => panic!("expected DS2 QP stream"),
+        };
+
+        let decoded = decode_to_buffer(&data).unwrap();
+        let mut streaming = StreamingDecoder::new();
+        let _ = streaming.push(&data).unwrap();
+
+        assert!(matches!(streaming.finish(), Err(DecodeError::Truncated(_))));
+        assert_eq!(decoded.format, AudioFormat::Ds2Qp);
+        assert_eq!(decoded.native_rate, 16000);
+        assert_eq!(decoded.samples, expected);
+    }
+
+    #[test]
+    fn test_decode_to_buffer_keeps_legacy_lenient_tail_handling_for_ds2_sp() {
+        let data = make_truncated_ds2_sp_file(13);
+
+        let expected = match demux_ds2(&data).unwrap() {
+            DemuxedDs2::Sp { packets, .. } => {
+                let mut decoder = Ds2SpDecoder::new();
+                let mut samples = Vec::new();
+                for packet in &packets {
+                    samples.extend_from_slice(&decoder.decode_frame(packet));
+                }
+                samples
+            }
+            _ => panic!("expected DS2 SP packets"),
+        };
+
+        let decoded = decode_to_buffer(&data).unwrap();
+        let mut streaming = StreamingDecoder::new();
+        let _ = streaming.push(&data).unwrap();
+
+        assert!(matches!(streaming.finish(), Err(DecodeError::Truncated(_))));
+        assert_eq!(decoded.format, AudioFormat::Ds2Sp);
+        assert_eq!(decoded.native_rate, 12000);
+        assert_eq!(decoded.samples, expected);
+    }
+
+    #[test]
+    fn test_decode_to_buffer_keeps_legacy_lenient_tail_handling_for_dss_sp() {
+        let data = make_truncated_dss_sp_file(13);
+
+        let expected = {
+            let (packets, _) = demux_dss(&data).unwrap();
+            let mut decoder = DssSpDecoder::new();
+            let mut samples = Vec::new();
+            for packet in &packets {
+                samples.extend(decoder.decode_frame(packet).into_iter().map(|sample| sample as f64));
+            }
+            samples
+        };
+
+        let decoded = decode_to_buffer(&data).unwrap();
+        let mut streaming = StreamingDecoder::new();
+        let _ = streaming.push(&data).unwrap();
+
+        assert!(matches!(streaming.finish(), Err(DecodeError::Truncated(_))));
+        assert_eq!(decoded.format, AudioFormat::DssSp);
+        assert_eq!(decoded.native_rate, 11025);
+        assert_eq!(decoded.samples, expected);
     }
 }
 
 /// Decode a file and write to WAV with given output configuration.
-pub fn decode_and_write(
-    input: &Path,
-    output: &Path,
-    config: &OutputConfig,
-) -> Result<AudioBuffer> {
+pub fn decode_and_write(input: &Path, output: &Path, config: &OutputConfig) -> Result<AudioBuffer> {
     let mut buf = decode_file(input)?;
 
     let target_rate = config.sample_rate.unwrap_or(buf.native_rate);
@@ -123,7 +189,13 @@ pub fn decode_and_write(
         buf.samples = resample(&buf.samples, buf.native_rate, target_rate)?;
     }
 
-    write_wav(output, &buf.samples, target_rate, config.bit_depth, config.channels)?;
+    write_wav(
+        output,
+        &buf.samples,
+        target_rate,
+        config.bit_depth,
+        config.channels,
+    )?;
 
     Ok(buf)
 }

--- a/dss-codec/src/streaming.rs
+++ b/dss-codec/src/streaming.rs
@@ -1,0 +1,290 @@
+use crate::codec::ds2_qp::Ds2QpDecoder;
+use crate::codec::ds2_sp::Ds2SpDecoder;
+use crate::codec::dss_sp::DssSpDecoder;
+use crate::demux::ds2::{Ds2QpStreamDemuxer, Ds2SpStreamDemuxer};
+use crate::demux::dss::DssSpStreamDemuxer;
+use crate::demux::{detect_format, AudioFormat};
+use crate::error::{DecodeError, Result};
+
+pub struct StreamingDecoder {
+    prebuffer: Vec<u8>,
+    format: Option<AudioFormat>,
+    demuxer: Option<ActiveDemuxer>,
+    decoder: Option<ActiveDecoder>,
+    finished: bool,
+}
+
+enum ActiveDemuxer {
+    Dss(DssSpStreamDemuxer),
+    Ds2Sp(Ds2SpStreamDemuxer),
+    Ds2Qp(Ds2QpStreamDemuxer),
+}
+
+enum ActiveDecoder {
+    Dss(DssSpDecoder),
+    Ds2Sp(Ds2SpDecoder),
+    Ds2Qp(Ds2QpDecoder),
+}
+
+impl StreamingDecoder {
+    pub fn new() -> Self {
+        Self {
+            prebuffer: Vec::new(),
+            format: None,
+            demuxer: None,
+            decoder: None,
+            finished: false,
+        }
+    }
+
+    pub fn push(&mut self, bytes: &[u8]) -> Result<Vec<f64>> {
+        if self.finished {
+            return Err(DecodeError::AlreadyFinished);
+        }
+
+        if self.format.is_none() {
+            self.prebuffer.extend_from_slice(bytes);
+            if !self.try_initialize()? {
+                return Ok(Vec::new());
+            }
+
+            let buffered = std::mem::take(&mut self.prebuffer);
+            return self.push_active(&buffered);
+        }
+
+        self.push_active(bytes)
+    }
+
+    pub fn finish(&mut self) -> Result<Vec<f64>> {
+        if self.finished {
+            return Ok(Vec::new());
+        }
+
+        if self.format.is_none() {
+            if self.prebuffer.is_empty() {
+                self.finished = true;
+                return Ok(Vec::new());
+            }
+
+            if self.try_initialize()? {
+                let buffered = std::mem::take(&mut self.prebuffer);
+                let mut samples = self.push_active(&buffered)?;
+                samples.extend(self.finish_active()?);
+                self.finished = true;
+                return Ok(samples);
+            }
+
+            return if self.prebuffer.len() >= 4 && self.prebuffer[..4] == *b"\x03ds2" {
+                Err(DecodeError::Truncated("DS2 header".to_string()))
+            } else if self.prebuffer.len() >= 4
+                && self.prebuffer[1..4] == *b"dss"
+                && (self.prebuffer[0] == 2 || self.prebuffer[0] == 3)
+            {
+                Err(DecodeError::Truncated("DSS header".to_string()))
+            } else {
+                Err(DecodeError::UnsupportedFormat(
+                    self.prebuffer.first().copied().unwrap_or(0),
+                ))
+            };
+        }
+
+        let samples = self.finish_active()?;
+        self.finished = true;
+        Ok(samples)
+    }
+
+    pub(crate) fn finish_lenient(&mut self) -> Result<Vec<f64>> {
+        if self.finished {
+            return Ok(Vec::new());
+        }
+
+        if self.format.is_none() {
+            if self.prebuffer.is_empty() {
+                self.finished = true;
+                return Ok(Vec::new());
+            }
+
+            if self.try_initialize()? {
+                let buffered = std::mem::take(&mut self.prebuffer);
+                let mut samples = self.push_active(&buffered)?;
+                samples.extend(self.finish_active_lenient()?);
+                self.finished = true;
+                return Ok(samples);
+            }
+
+            return if self.prebuffer.len() >= 4 && self.prebuffer[..4] == *b"\x03ds2" {
+                Err(DecodeError::Truncated("DS2 header".to_string()))
+            } else if self.prebuffer.len() >= 4
+                && self.prebuffer[1..4] == *b"dss"
+                && (self.prebuffer[0] == 2 || self.prebuffer[0] == 3)
+            {
+                Err(DecodeError::Truncated("DSS header".to_string()))
+            } else {
+                Err(DecodeError::UnsupportedFormat(
+                    self.prebuffer.first().copied().unwrap_or(0),
+                ))
+            };
+        }
+
+        let samples = self.finish_active_lenient()?;
+        self.finished = true;
+        Ok(samples)
+    }
+
+    pub fn format(&self) -> Option<AudioFormat> {
+        self.format
+    }
+
+    pub fn native_rate(&self) -> Option<u32> {
+        self.format.map(|fmt| fmt.native_sample_rate())
+    }
+
+    fn try_initialize(&mut self) -> Result<bool> {
+        if let Some(format) = detect_format(&self.prebuffer) {
+            self.initialize_for_format(format);
+            return Ok(true);
+        }
+
+        if self.prebuffer.len() >= 4 {
+            let is_dss_prefix = self.prebuffer[1..4] == *b"dss"
+                && (self.prebuffer[0] == 2 || self.prebuffer[0] == 3);
+            let is_ds2_prefix = self.prebuffer[..4] == *b"\x03ds2";
+            if !is_dss_prefix && !is_ds2_prefix {
+                return Err(DecodeError::UnsupportedFormat(
+                    self.prebuffer.first().copied().unwrap_or(0),
+                ));
+            }
+        }
+
+        Ok(false)
+    }
+
+    fn initialize_for_format(&mut self, format: AudioFormat) {
+        self.format = Some(format);
+        match format {
+            AudioFormat::DssSp => {
+                let version = self.prebuffer[0];
+                self.demuxer = Some(ActiveDemuxer::Dss(DssSpStreamDemuxer::new(version)));
+                self.decoder = Some(ActiveDecoder::Dss(DssSpDecoder::new()));
+            }
+            AudioFormat::Ds2Sp => {
+                self.demuxer = Some(ActiveDemuxer::Ds2Sp(Ds2SpStreamDemuxer::new()));
+                self.decoder = Some(ActiveDecoder::Ds2Sp(Ds2SpDecoder::new()));
+            }
+            AudioFormat::Ds2Qp => {
+                self.demuxer = Some(ActiveDemuxer::Ds2Qp(Ds2QpStreamDemuxer::new()));
+                self.decoder = Some(ActiveDecoder::Ds2Qp(Ds2QpDecoder::new()));
+            }
+        }
+    }
+
+    fn push_active(&mut self, bytes: &[u8]) -> Result<Vec<f64>> {
+        let frames = match self.demuxer.as_mut() {
+            Some(ActiveDemuxer::Dss(demuxer)) => demuxer.push(bytes)?,
+            Some(ActiveDemuxer::Ds2Sp(demuxer)) => demuxer.push(bytes)?,
+            Some(ActiveDemuxer::Ds2Qp(demuxer)) => demuxer.push(bytes)?,
+            None => return Ok(Vec::new()),
+        };
+
+        self.decode_frames(frames)
+    }
+
+    fn finish_active(&mut self) -> Result<Vec<f64>> {
+        let frames = match self.demuxer.as_mut() {
+            Some(ActiveDemuxer::Dss(demuxer)) => demuxer.finish()?,
+            Some(ActiveDemuxer::Ds2Sp(demuxer)) => demuxer.finish()?,
+            Some(ActiveDemuxer::Ds2Qp(demuxer)) => demuxer.finish()?,
+            None => Vec::new(),
+        };
+
+        self.decode_frames(frames)
+    }
+
+    fn finish_active_lenient(&mut self) -> Result<Vec<f64>> {
+        let frames = match self.demuxer.as_mut() {
+            Some(ActiveDemuxer::Dss(demuxer)) => demuxer.finish_lenient()?,
+            Some(ActiveDemuxer::Ds2Sp(demuxer)) => demuxer.finish_lenient()?,
+            Some(ActiveDemuxer::Ds2Qp(demuxer)) => demuxer.finish_lenient()?,
+            None => Vec::new(),
+        };
+
+        self.decode_frames(frames)
+    }
+
+    fn decode_frames(&mut self, frames: Vec<Vec<u8>>) -> Result<Vec<f64>> {
+        let mut samples = Vec::new();
+        match self.decoder.as_mut() {
+            Some(ActiveDecoder::Dss(decoder)) => {
+                for frame in frames {
+                    let frame_samples = decoder.decode_frame(&frame);
+                    samples.extend(frame_samples.into_iter().map(|sample| sample as f64));
+                }
+            }
+            Some(ActiveDecoder::Ds2Sp(decoder)) => {
+                for frame in frames {
+                    samples.extend_from_slice(&decoder.decode_frame(&frame));
+                }
+            }
+            Some(ActiveDecoder::Ds2Qp(decoder)) => {
+                for frame in frames {
+                    samples.extend_from_slice(&decoder.decode_frame(&frame));
+                }
+            }
+            None => {}
+        }
+
+        Ok(samples)
+    }
+}
+
+impl Default for StreamingDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_ds2_header_only(mode: u8) -> Vec<u8> {
+        let mut data = vec![0u8; 0x600 + 512];
+        data[..4].copy_from_slice(b"\x03ds2");
+        data[0x600 + 4] = mode;
+        data
+    }
+
+    #[test]
+    fn test_streaming_decoder_detects_only_when_enough_bytes_arrive() {
+        let data = make_ds2_header_only(6);
+        let mut decoder = StreamingDecoder::new();
+
+        let first = decoder.push(&data[..4]).unwrap();
+        assert!(first.is_empty());
+        assert_eq!(decoder.format(), None);
+        assert_eq!(decoder.native_rate(), None);
+
+        let second = decoder.push(&data[4..]).unwrap();
+        assert!(second.is_empty());
+        assert_eq!(decoder.format(), Some(AudioFormat::Ds2Qp));
+        assert_eq!(decoder.native_rate(), Some(16000));
+    }
+
+    #[test]
+    fn test_streaming_decoder_truncated_header_on_finish() {
+        let mut decoder = StreamingDecoder::new();
+        let _ = decoder.push(b"\x03ds2").unwrap();
+
+        let err = decoder.finish().unwrap_err();
+        assert!(matches!(err, DecodeError::Truncated(_)));
+    }
+
+    #[test]
+    fn test_streaming_decoder_push_after_finish_errors() {
+        let mut decoder = StreamingDecoder::new();
+        let _ = decoder.finish().unwrap();
+
+        let err = decoder.push(b"\x03ds2").unwrap_err();
+        assert!(matches!(err, DecodeError::AlreadyFinished));
+    }
+}


### PR DESCRIPTION
Add a lower-level streaming decode API for supported DSS/DS2 formats and move the existing batch decode path onto that implementation.

This introduces a new public `StreamingDecoder` that accepts incremental byte input and returns decoded PCM chunks, while keeping the existing batch/file-oriented API unchanged.

- add public `streaming::StreamingDecoder`
- add incremental demuxers for:
  - DSS SP
  - DS2 SP
  - DS2 QP
- add single-frame decode entry point for DS2 QP so batch and streaming share the same core path
- route `decode_to_buffer`, `decode_file`, and `decode_and_write` through the streaming implementation
- preserve legacy batch behavior on truncated tails, while keeping `StreamingDecoder::finish()` strict on incomplete input

Example use:

```
use dss_codec::streaming::StreamingDecoder;
use std::fs::File;
use std::io::Read;

let mut file = File::open("recording.ds2")?;
let mut decoder = StreamingDecoder::new();
let mut buf = [0u8; 4096];
let mut samples = Vec::new();

loop {
    let n = file.read(&mut buf)?;
    if n == 0 {
        break;
    }
    samples.extend(decoder.push(&buf[..n])?);
}

samples.extend(decoder.finish()?);
```
