### PR TITLE
Added support for 128bit and 256bit password encrypted ds2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  build-and-test:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+
+    defaults:
+      run:
+        working-directory: dss-codec
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ""
+          cache-workspaces: dss-codec -> target
+
+      - name: Build
+        run: cargo build --locked
+
+      - name: Test
+        run: cargo test --locked

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Open-source decoder for Olympus DSS and DS2 (DSS Pro) proprietary dictation audio formats. Converts `.dss` and `.ds2` files to standard WAV.
 
+Also supports password-protected DS2 files when a password is provided.
+
 The codec was fully reverse-engineered from Olympus's DssDecoder.dll using Ghidra. The decoder produces output matching the proprietary DLL (1.0000 correlation, bit-exact on all tested files).
 
 ## Quick Start
@@ -15,6 +17,12 @@ cargo build --release
 
 # Resample to 16kHz (useful for ASR pipelines)
 ./target/release/dss-decode -r 16000 recording.DS2
+
+# Decode an encrypted DS2 file with a password
+./target/release/dss-decode --password 1234 recording.DS2
+
+# Decode an encrypted DS2 file using an environment variable
+DSS_CODEC_PASSWORD=1234 ./target/release/dss-decode recording.DS2
 ```
 
 ## Supported Formats
@@ -24,6 +32,8 @@ cargo build --release
 | `.dss` (v2/v3) | DSS SP | 11025 Hz | Header `{02\|03}dss` |
 | `.ds2` mode 0-1 | DS2 SP | 12000 Hz | Header `\x03ds2`, byte4 < 6 |
 | `.ds2` mode 6-7 | DS2 QP | 16000 Hz | Header `\x03ds2`, byte4 >= 6 |
+
+Encrypted DS2 files with header `\x03enc` are also supported when a password is provided.
 
 ## Project Structure
 

--- a/dss-codec/CODEC_SPECIFICATION.md
+++ b/dss-codec/CODEC_SPECIFICATION.md
@@ -8,18 +8,19 @@ Complete technical specification for the Olympus DSS and DS2 proprietary speech 
 
 1. [Overview](#overview)
 2. [File Formats](#file-formats)
-3. [Bitstream Reader](#bitstream-reader)
-4. [Demuxing](#demuxing)
-5. [DSS SP Decoder](#dss-sp-decoder)
-6. [DS2 SP Decoder](#ds2-sp-decoder)
-7. [DS2 QP Decoder](#ds2-qp-decoder)
-8. [Shared Algorithms](#shared-algorithms)
-9. [All Quantization Tables](#all-quantization-tables)
-10. [All Codebook Tables](#all-codebook-tables)
-11. [Python Reference Decoders](#python-reference-decoders)
-12. [Rust Implementation](#rust-implementation)
-13. [Verification Results](#verification-results)
-14. [DLL Function Map](#dll-function-map)
+3. [Encrypted Variant Notes](#encrypted-variant-notes)
+4. [Bitstream Reader](#bitstream-reader)
+5. [Demuxing](#demuxing)
+6. [DSS SP Decoder](#dss-sp-decoder)
+7. [DS2 SP Decoder](#ds2-sp-decoder)
+8. [DS2 QP Decoder](#ds2-qp-decoder)
+9. [Shared Algorithms](#shared-algorithms)
+10. [All Quantization Tables](#all-quantization-tables)
+11. [All Codebook Tables](#all-codebook-tables)
+12. [Python Reference Decoders](#python-reference-decoders)
+13. [Rust Implementation](#rust-implementation)
+14. [Verification Results](#verification-results)
+15. [DLL Function Map](#dll-function-map)
 
 ---
 
@@ -100,6 +101,225 @@ All audio data is organized in 512-byte blocks:
 | 6-511 | 506 | Audio payload |
 
 Frame count in block headers sums to total frame count for the file.
+
+---
+
+  ## Encrypted Variant Notes
+
+  ### High-Level Overview
+
+  Encrypted DS2 is not a different container format. It is normal DS2 with:
+
+  - file magic changed from \x03ds2 to \x03enc
+  - a 22-byte decrypt descriptor embedded in the header
+  - each 512-byte audio block transformed only over a 496-byte window
+
+  The block structure and DS2 framing remain intact. The 6-byte DS2 block header is left in clear, and the final 10
+  bytes of each 512-byte block are outside the transform window.
+
+  Cryptographically, the payload transform is:
+
+  - password-derived AES key material
+  - applied to each block as a custom self-rekeying AES decrypt mode
+  - with an adjacent-byte swap before and after the AES step
+
+  The implementation problem is not "decrypt an entire file with CBC/CTR/etc." It is:
+
+  1. parse the descriptor
+  2. derive the initial AES key from password + aux_16
+  3. initialize a small saved-state blob
+  4. for each 512-byte DS2 block, transform only bytes 6..501
+  5. after each 16-byte AES block, derive the next AES key from the current AES state
+
+  ### File-Level Structure
+
+  - Plain DS2 magic: \x03ds2
+  - Encrypted DS2 magic: \x03enc
+  - Header size remains 0x600
+  - Audio still begins at 0x600
+  - Audio remains organized as 512-byte blocks
+
+  Each encrypted block keeps the normal 6-byte DS2 block header unchanged:
+
+  | Offset | Size | Meaning |
+  |---|---:|---|
+  | 0..5 | 6 | Normal DS2 block header |
+  | 6..501 | 496 (0x1f0) | Encrypted/transformed payload window |
+  | 502..511 | 10 | Untouched payload tail |
+
+  Important consequence:
+
+  - the logical DS2 payload area is still 506 bytes wide
+  - but only the first 496 bytes of that area are transformed
+  - bytes 502..511 are not part of the crypto window
+
+  ### Decrypt Descriptor
+
+  Encrypted DS2 stores a 22-byte decrypt descriptor at header offset 0x146.
+
+  | Relative Offset | Size | Meaning |
+  |---|---:|---|
+  | 0x00..0x01 | 2 | Mode: 0x0001 = AES-128, 0x0002 = AES-256 |
+  | 0x02..0x11 | 16 | aux_16 block |
+  | 0x12..0x13 | 2 | Expected check word, little-endian |
+  | 0x14..0x15 | 2 | Present in the 22-byte descriptor, not required for decryption |
+
+  For a practical decoder, the useful fields are:
+
+  - key mode
+  - aux_16
+  - expected check word
+
+  ### Password Mixing and Key Derivation
+
+  Passwords are treated as raw bytes and are limited to 16 bytes.
+
+  Derivation process:
+
+  1. Zero-pad the password to 16 bytes.
+  2. XOR the padded password with aux_16.
+  3. Hash the resulting 16-byte mixed block.
+
+  For AES-128 (mode = 1):
+
+  - digest = SHA-1(mixed_16)
+  - key = digest[0..15]
+  - check dword = little-endian digest[16..19]
+  - compared check word = low 16 bits of that dword
+
+  For AES-256 (mode = 2):
+
+  - digest = SHA-384(mixed_16)
+  - key = digest[0..31]
+  - check dword = little-endian digest[32..35]
+  - compared check word = low 16 bits of that dword
+
+  The derived low-16-bit check word must match the descriptor before any payload block is decrypted.
+
+  ### Saved Decrypt State
+
+  The vendor builds and saves a 0x12c-byte decrypt-state blob.
+
+  Useful layout:
+
+  - +0x000 .. +0x00f : zeroed prefix
+  - +0x010 .. +0x01f : current plaintext 16-byte block
+  - +0x020 .. +0x127 : AES state / schedule blob
+  - +0x120 : AES round count
+  - +0x124 : flags (0x12 when ready)
+  - +0x128 : block byte index
+
+  Initialization behavior:
+
+  - zero +0x000 .. +0x00f
+  - set block_byte_index = 0x10
+  - expand the derived AES key into the AES state area at +0x20
+
+  ### Per-Block Transform
+
+  For each 512-byte DS2 block:
+
+  1. Take bytes 6..501 as the 496-byte transformed window.
+  2. Byte-swap each adjacent pair in that window.
+  3. Run the self-rekeying AES decrypt loop.
+  4. Byte-swap each adjacent pair again.
+  5. Write the result back to bytes 6..501.
+  6. Leave bytes 0..5 and 502..511 unchanged.
+
+  This means the transformed window is exactly 31 AES blocks of 16 bytes.
+
+  ### Self-Rekeying AES Loop
+
+  The transformed 496-byte window is processed as 31 AES blocks.
+
+  For each 16-byte chunk:
+
+  1. AES-decrypt the ciphertext block with the current key state.
+  2. Store the plaintext block at saved-state offset +0x10.
+  3. Derive the next AES key from the current AES state blob.
+  4. Expand/install that next key immediately.
+  5. Output the plaintext block.
+
+  The rekey source begins at:
+
+  (round_count + 2) * 0x10
+
+  within the saved-state blob.
+
+  That formula is important. It is not arbitrary:
+
+  - for AES-128 (round_count = 10), it points at state + 0x0c0
+  - for AES-256 (round_count = 14), it points at state + 0x100
+
+  Those locations correspond to the final-round key words in the vendor AES state blob.
+
+  #### AES-128 Rekey
+
+  - read 16 bytes from the rekey source
+  - use those 16 bytes directly as the next AES-128 key
+
+  #### AES-256 Rekey
+
+  1. Read 16 bytes from the rekey source as four big-endian 32-bit words:
+
+  [w0, w1, w2, w3]
+
+  2. Form the next 32-byte key as:
+
+  [w0, w1, w2, w3, w1, w0, w3, w2]
+
+  3. Serialize those eight words back as big-endian 32-bit words.
+  4. Expand/install that as the next AES-256 key.
+
+  This reshuffle is one of the main non-obvious details that must be implemented exactly.
+
+  ### AES State Representation
+
+  The saved-state AES words are stored in big-endian word order.
+
+  The vendor's in-memory AES blob is not just a textbook expanded key array:
+
+  - the first key words are stored raw
+  - the final round-key words are stored raw
+  - middle-round material is stored in a T-table-oriented decrypt form
+
+  For a clean decoder, you do not have to reproduce that vendor blob byte-for-byte if your AES decrypt
+  implementation produces the same block outputs. A normal AES key expansion plus inverse-round decrypt
+  implementation is sufficient for a clean implementation.
+
+  But for byte-level oracle matching, the vendor blob layout matters.
+
+  ### Important Non-Findings / Things Not To Overcomplicate
+
+  - The last 10 bytes of each 512-byte block are not part of the transform window.
+  - The 6-byte DS2 block header is not encrypted.
+  - This is not CBC, CTR, OFB, or ECB over the full block stream.
+  - The file is not reorganized; it is still normal DS2 framing with an encrypted payload window.
+
+  ### Decoder Integration
+
+  After block decryption:
+
+  - rewrite file magic from \x03enc to \x03ds2
+  - leave header structure otherwise intact
+  - decrypt each 512-byte audio block as above
+  - feed the result into the normal DS2 demux/decode path
+
+  ### Practical Implementation Notes
+
+  These are the details most likely to save another developer time:
+
+  - Treat the password as raw bytes, not UTF-16 text.
+  - Enforce the 16-byte password cap.
+  - Parse the descriptor from header offset 0x146.
+  - Compare only the low 16 bits of the derived check dword.
+  - Transform only bytes 6..501.
+  - Swap adjacent bytes before and after the AES loop.
+  - Maintain the saved-state block byte index at +0x128.
+  - Rekey after every 16-byte AES block.
+  - Read/write AES rekey words as big-endian 32-bit values.
+  - For AES-256, do not miss the [w1,w0,w3,w2] second half.
+  - Do not assume bytes 502..511 carry encrypted audio payload.
 
 ---
 

--- a/dss-codec/Cargo.lock
+++ b/dss-codec/Cargo.lock
@@ -68,6 +68,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "clap"
 version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +129,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "dss-codec"
 version = "0.1.0"
 dependencies = [
@@ -121,7 +165,19 @@ dependencies = [
  "clap",
  "hound",
  "rubato",
+ "sha1",
+ "sha2",
  "thiserror",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -141,6 +197,12 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "libc"
+version = "0.2.185"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "num-complex"
@@ -238,6 +300,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +375,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +391,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "windows-link"

--- a/dss-codec/Cargo.toml
+++ b/dss-codec/Cargo.toml
@@ -14,6 +14,8 @@ clap = { version = "4", features = ["derive"] }
 thiserror = "2"
 hound = "3"
 rubato = "0.16"
+sha1 = "0.10"
+sha2 = "0.10"
 
 [dev-dependencies]
 approx = "0.5"

--- a/dss-codec/src/codec/ds2_qp.rs
+++ b/dss-codec/src/codec/ds2_qp.rs
@@ -60,21 +60,25 @@ impl Ds2QpDecoder {
         let mut all_samples = Vec::with_capacity(total_frames * SAMPLES_PER_FRAME);
 
         for _ in 0..total_frames {
-            let samples = self.decode_frame_from_reader(&mut reader);
+            let mut frame = [0u8; 56];
+            for word in 0..28 {
+                let value = reader.read_bits(16) as u16;
+                frame[word * 2] = value as u8;
+                frame[word * 2 + 1] = (value >> 8) as u8;
+            }
+            let samples = self.decode_frame(&frame);
             all_samples.extend_from_slice(&samples);
         }
 
-        // Apply de-emphasis: y[n] = x[n] + 0.1*y[n-1]
-        let alpha = 0.1;
-        if !all_samples.is_empty() {
-            all_samples[0] += alpha * self.deemph_state;
-            for i in 1..all_samples.len() {
-                all_samples[i] += alpha * all_samples[i - 1];
-            }
-            self.deemph_state = *all_samples.last().unwrap();
-        }
-
         all_samples
+    }
+
+    /// Decode a single QP frame from its 56-byte payload.
+    pub fn decode_frame(&mut self, frame_bytes: &[u8]) -> Vec<f64> {
+        let mut reader = BitstreamReader::new(frame_bytes);
+        let mut samples = self.decode_frame_from_reader(&mut reader);
+        self.apply_deemphasis(&mut samples);
+        samples
     }
 
     fn decode_frame_from_reader(&mut self, reader: &mut BitstreamReader) -> Vec<f64> {
@@ -131,8 +135,7 @@ impl Ds2QpDecoder {
 
             // Fixed codebook excitation
             let gc = QP_EXCITATION_GAIN[*gain_idx];
-            let positions =
-                decode_combinatorial_index(*cb_idx, SUBFRAME_SIZE, EXCITATION_PULSES);
+            let positions = decode_combinatorial_index(*cb_idx, SUBFRAME_SIZE, EXCITATION_PULSES);
             let mut fixed_exc = [0.0f64; SUBFRAME_SIZE];
             for (pi, &pos) in positions.iter().enumerate() {
                 if pos < SUBFRAME_SIZE {
@@ -159,5 +162,16 @@ impl Ds2QpDecoder {
         }
 
         all_output
+    }
+
+    fn apply_deemphasis(&mut self, samples: &mut [f64]) {
+        let alpha = 0.1;
+        if !samples.is_empty() {
+            samples[0] += alpha * self.deemph_state;
+            for i in 1..samples.len() {
+                samples[i] += alpha * samples[i - 1];
+            }
+            self.deemph_state = *samples.last().unwrap();
+        }
     }
 }

--- a/dss-codec/src/crypto/ds2_encrypted.rs
+++ b/dss-codec/src/crypto/ds2_encrypted.rs
@@ -1,0 +1,637 @@
+use crate::error::{DecodeError, Result};
+use sha1::{Digest as Sha1Digest, Sha1};
+use sha2::Sha384;
+
+pub const ENCRYPTED_MAGIC: [u8; 4] = *b"\x03enc";
+pub const PLAIN_MAGIC: [u8; 4] = *b"\x03ds2";
+pub const DS2_HEADER_SIZE: usize = 0x600;
+pub const DS2_BLOCK_SIZE: usize = 0x200;
+pub const DS2_BLOCK_HEADER_SIZE: usize = 6;
+pub const DECRYPT_DESCRIPTOR_OFFSET: usize = 0x146;
+pub const DECRYPT_DESCRIPTOR_SIZE: usize = 22;
+pub const TRANSFORMED_BODY_SIZE: usize = 0x1f0;
+const SAVED_STATE_SIZE: usize = 0x12c;
+const CURRENT_BLOCK_OFFSET: usize = 0x10;
+const AES_STATE_OFFSET: usize = 0x20;
+const AES_ROUND_COUNT_OFFSET: usize = 0x120;
+const AES_FLAGS_OFFSET: usize = 0x124;
+const BLOCK_BYTE_INDEX_OFFSET: usize = 0x128;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyMode {
+    Aes128 = 1,
+    Aes256 = 2,
+}
+
+impl KeyMode {
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecryptDescriptor {
+    pub key_mode: KeyMode,
+    pub aux_16: [u8; 16],
+    pub expected_check_word: u16,
+}
+
+#[doc(hidden)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DebugDecryptTrace {
+    pub mode: KeyMode,
+    pub expected_check_word: u16,
+    pub saved_state: Vec<u8>,
+    pub swapped_body: Vec<u8>,
+    pub first_decrypted_16: [u8; 16],
+    pub second_decrypted_16: [u8; 16],
+    pub post_rekey_state_prefix: Vec<u8>,
+    pub final_block: Vec<u8>,
+}
+
+#[derive(Clone)]
+struct PayloadDecryptState {
+    blob: [u8; SAVED_STATE_SIZE],
+}
+
+impl Default for PayloadDecryptState {
+    fn default() -> Self {
+        Self {
+            blob: [0; SAVED_STATE_SIZE],
+        }
+    }
+}
+
+impl PayloadDecryptState {
+    fn round_key_word(&self, index: usize) -> u32 {
+        let offset = AES_STATE_OFFSET + index * 4;
+        load_be32(&self.blob[offset..offset + 4])
+    }
+
+    fn set_round_key_word(&mut self, index: usize, word: u32) {
+        let offset = AES_STATE_OFFSET + index * 4;
+        store_be32(&mut self.blob[offset..offset + 4], word);
+    }
+
+    fn round_count(&self) -> usize {
+        u32::from_le_bytes(
+            self.blob[AES_ROUND_COUNT_OFFSET..AES_ROUND_COUNT_OFFSET + 4]
+                .try_into()
+                .unwrap(),
+        ) as usize
+    }
+
+    fn set_round_count(&mut self, rounds: usize) {
+        self.blob[AES_ROUND_COUNT_OFFSET..AES_ROUND_COUNT_OFFSET + 4]
+            .copy_from_slice(&(rounds as u32).to_le_bytes());
+    }
+
+    fn set_flags(&mut self, flags: u32) {
+        self.blob[AES_FLAGS_OFFSET..AES_FLAGS_OFFSET + 4].copy_from_slice(&flags.to_le_bytes());
+    }
+
+    fn block_byte_index(&self) -> usize {
+        u32::from_le_bytes(
+            self.blob[BLOCK_BYTE_INDEX_OFFSET..BLOCK_BYTE_INDEX_OFFSET + 4]
+                .try_into()
+                .unwrap(),
+        ) as usize
+    }
+
+    fn set_block_byte_index(&mut self, index: usize) {
+        self.blob[BLOCK_BYTE_INDEX_OFFSET..BLOCK_BYTE_INDEX_OFFSET + 4]
+            .copy_from_slice(&(index as u32).to_le_bytes());
+    }
+
+    fn current_block(&self) -> &[u8] {
+        &self.blob[CURRENT_BLOCK_OFFSET..CURRENT_BLOCK_OFFSET + 16]
+    }
+
+    fn current_block_mut(&mut self) -> &mut [u8] {
+        &mut self.blob[CURRENT_BLOCK_OFFSET..CURRENT_BLOCK_OFFSET + 16]
+    }
+
+    fn rekey_source_128(&self) -> [u8; 16] {
+        let start = (self.round_count() + 2) * 0x10;
+        self.blob[start..start + 16].try_into().unwrap()
+    }
+
+    fn rekey_source_256(&self) -> [u8; 32] {
+        let start = (self.round_count() + 2) * 0x10;
+        let source = &self.blob[start..start + 16];
+        let mut words = [0u32; 8];
+        for (i, chunk) in source.chunks_exact(4).enumerate() {
+            words[i] = load_be32(chunk);
+        }
+        words[4] = words[1];
+        words[5] = words[0];
+        words[6] = words[3];
+        words[7] = words[2];
+
+        let mut out = [0u8; 32];
+        for (i, word) in words.iter().enumerate() {
+            store_be32(&mut out[i * 4..(i + 1) * 4], *word);
+        }
+        out
+    }
+}
+
+pub fn parse_decrypt_descriptor(data: &[u8]) -> Result<DecryptDescriptor> {
+    let raw = data
+        .get(DECRYPT_DESCRIPTOR_OFFSET..DECRYPT_DESCRIPTOR_OFFSET + DECRYPT_DESCRIPTOR_SIZE)
+        .ok_or_else(|| DecodeError::EncryptedDs2("missing decrypt descriptor".to_string()))?;
+
+    let key_mode = match u16::from_le_bytes(raw[0..2].try_into().unwrap()) {
+        1 => KeyMode::Aes128,
+        2 => KeyMode::Aes256,
+        mode => {
+            return Err(DecodeError::EncryptedDs2(format!(
+                "unsupported encrypted DS2 key mode {mode}"
+            )))
+        }
+    };
+
+    let mut aux_16 = [0u8; 16];
+    aux_16.copy_from_slice(&raw[2..18]);
+
+    Ok(DecryptDescriptor {
+        key_mode,
+        aux_16,
+        expected_check_word: u16::from_le_bytes(raw[18..20].try_into().unwrap()),
+    })
+}
+
+pub fn decrypt_encrypted_ds2(data: &[u8], password: &[u8]) -> Result<Vec<u8>> {
+    if data.len() < DS2_HEADER_SIZE {
+        return Err(DecodeError::Truncated("encrypted DS2 header".to_string()));
+    }
+    if data[..4] != ENCRYPTED_MAGIC {
+        return Err(DecodeError::EncryptedDs2(
+            "expected encrypted DS2 magic \\x03enc".to_string(),
+        ));
+    }
+    if password.len() > 16 {
+        return Err(DecodeError::EncryptedDs2(
+            "password longer than 16 bytes is not supported by current prototype".to_string(),
+        ));
+    }
+
+    let descriptor = parse_decrypt_descriptor(data)?;
+    let saved_state = build_saved_state(password, &descriptor)?;
+
+    let mut out = data.to_vec();
+    out[..4].copy_from_slice(&PLAIN_MAGIC);
+
+    let mut offset = DS2_HEADER_SIZE;
+    while offset + DS2_BLOCK_SIZE <= out.len() {
+        decrypt_record_in_place(&saved_state, descriptor.key_mode, &mut out[offset..offset + DS2_BLOCK_SIZE])?;
+        offset += DS2_BLOCK_SIZE;
+    }
+
+    Ok(out)
+}
+
+#[doc(hidden)]
+pub fn debug_decrypt_block(
+    data: &[u8],
+    password: &[u8],
+    block_index: usize,
+) -> Result<DebugDecryptTrace> {
+    if data.len() < DS2_HEADER_SIZE + DS2_BLOCK_SIZE {
+        return Err(DecodeError::Truncated("encrypted DS2 block".to_string()));
+    }
+    if data[..4] != ENCRYPTED_MAGIC {
+        return Err(DecodeError::EncryptedDs2(
+            "expected encrypted DS2 magic \\x03enc".to_string(),
+        ));
+    }
+
+    let descriptor = parse_decrypt_descriptor(data)?;
+    let saved_state = build_saved_state(password, &descriptor)?;
+
+    let block_offset = DS2_HEADER_SIZE + block_index * DS2_BLOCK_SIZE;
+    let block = data
+        .get(block_offset..block_offset + DS2_BLOCK_SIZE)
+        .ok_or_else(|| DecodeError::Truncated("encrypted DS2 block index".to_string()))?;
+
+    let mut final_block = block.to_vec();
+    let mut swapped_body =
+        final_block[DS2_BLOCK_HEADER_SIZE..DS2_BLOCK_HEADER_SIZE + TRANSFORMED_BODY_SIZE].to_vec();
+    swap_adjacent_bytes(&mut swapped_body);
+
+    let mut state_for_core = saved_state.clone();
+    let mut core_body = swapped_body.clone();
+    decrypt_body_self_rekey(&mut core_body, &mut state_for_core, descriptor.key_mode)?;
+
+    final_block[DS2_BLOCK_HEADER_SIZE..DS2_BLOCK_HEADER_SIZE + TRANSFORMED_BODY_SIZE]
+        .copy_from_slice(&core_body);
+    swap_adjacent_bytes(
+        &mut final_block[DS2_BLOCK_HEADER_SIZE..DS2_BLOCK_HEADER_SIZE + TRANSFORMED_BODY_SIZE],
+    );
+
+    let mut first_decrypted_16 = [0u8; 16];
+    first_decrypted_16.copy_from_slice(&core_body[..16]);
+    let mut second_decrypted_16 = [0u8; 16];
+    second_decrypted_16.copy_from_slice(&core_body[16..32]);
+
+    Ok(DebugDecryptTrace {
+        mode: descriptor.key_mode,
+        expected_check_word: descriptor.expected_check_word,
+        saved_state: saved_state.blob.to_vec(),
+        swapped_body,
+        first_decrypted_16,
+        second_decrypted_16,
+        post_rekey_state_prefix: state_for_core.blob[..96].to_vec(),
+        final_block,
+    })
+}
+
+fn build_saved_state(password: &[u8], descriptor: &DecryptDescriptor) -> Result<PayloadDecryptState> {
+    let (derived_key, computed_check_word) = match descriptor.key_mode {
+        KeyMode::Aes128 => {
+            let (key, check) = derive_key_128(password, &descriptor.aux_16)?;
+            (key.to_vec(), check)
+        }
+        KeyMode::Aes256 => {
+            let (key, check) = derive_key_256(password, &descriptor.aux_16)?;
+            (key.to_vec(), check)
+        }
+    };
+
+    if computed_check_word != descriptor.expected_check_word {
+        return Err(DecodeError::EncryptedDs2(format!(
+            "password rejected by descriptor check: expected 0x{:04x}, computed 0x{:04x}",
+            descriptor.expected_check_word, computed_check_word
+        )));
+    }
+
+    let mut state = PayloadDecryptState::default();
+    state.set_block_byte_index(0x10);
+    aes_expand_key(&mut state, &derived_key)?;
+    Ok(state)
+}
+
+fn decrypt_record_in_place(
+    saved_state: &PayloadDecryptState,
+    key_mode: KeyMode,
+    record: &mut [u8],
+) -> Result<()> {
+    if record.len() != DS2_BLOCK_SIZE {
+        return Err(DecodeError::EncryptedDs2(format!(
+            "expected {}-byte DS2 record, got {} bytes",
+            DS2_BLOCK_SIZE,
+            record.len()
+        )));
+    }
+
+    let body = &mut record[DS2_BLOCK_HEADER_SIZE..DS2_BLOCK_HEADER_SIZE + TRANSFORMED_BODY_SIZE];
+    swap_adjacent_bytes(body);
+
+    let mut state = saved_state.clone();
+    decrypt_body_self_rekey(body, &mut state, key_mode)?;
+
+    swap_adjacent_bytes(body);
+    Ok(())
+}
+
+fn derive_key_128(password: &[u8], aux_16: &[u8; 16]) -> Result<([u8; 16], u16)> {
+    let mixed = mix_password(password, aux_16)?;
+    let digest = Sha1::digest(mixed);
+
+    let mut key = [0u8; 16];
+    key.copy_from_slice(&digest[..16]);
+    let check_word = u16::from_le_bytes([digest[16], digest[17]]);
+    Ok((key, check_word))
+}
+
+fn derive_key_256(password: &[u8], aux_16: &[u8; 16]) -> Result<([u8; 32], u16)> {
+    let mixed = mix_password(password, aux_16)?;
+    let digest = Sha384::digest(mixed);
+
+    let mut key = [0u8; 32];
+    key.copy_from_slice(&digest[..32]);
+    let check_word = u16::from_le_bytes([digest[32], digest[33]]);
+    Ok((key, check_word))
+}
+
+fn mix_password(password: &[u8], aux_16: &[u8; 16]) -> Result<[u8; 16]> {
+    if password.len() > 16 {
+        return Err(DecodeError::EncryptedDs2(
+            "password longer than 16 bytes is not supported by current prototype".to_string(),
+        ));
+    }
+
+    let mut mixed = [0u8; 16];
+    mixed[..password.len()].copy_from_slice(password);
+    for (dst, aux) in mixed.iter_mut().zip(aux_16) {
+        *dst ^= *aux;
+    }
+    Ok(mixed)
+}
+
+fn swap_adjacent_bytes(bytes: &mut [u8]) {
+    for pair in bytes.chunks_exact_mut(2) {
+        pair.swap(0, 1);
+    }
+}
+
+fn decrypt_body_self_rekey(
+    body: &mut [u8],
+    state: &mut PayloadDecryptState,
+    key_mode: KeyMode,
+) -> Result<()> {
+    if body.len() % 16 != 0 {
+        return Err(DecodeError::EncryptedDs2(format!(
+            "transformed body length {} is not a multiple of 16",
+            body.len()
+        )));
+    }
+
+    for chunk in body.chunks_exact_mut(16) {
+        if state.block_byte_index() == 0x10 {
+            let plaintext = aes_decrypt_block(state, chunk)?;
+            state.current_block_mut().copy_from_slice(&plaintext);
+
+            match key_mode {
+                KeyMode::Aes128 => {
+                    let rekey = state.rekey_source_128();
+                    aes_expand_key(state, &rekey)?;
+                }
+                KeyMode::Aes256 => {
+                    let rekey = state.rekey_source_256();
+                    aes_expand_key(state, &rekey)?;
+                }
+            }
+            state.set_block_byte_index(0);
+        }
+
+        chunk.copy_from_slice(state.current_block());
+        state.set_block_byte_index(0x10);
+    }
+
+    Ok(())
+}
+
+fn aes_expand_key(state: &mut PayloadDecryptState, key: &[u8]) -> Result<()> {
+    let (nk, nr) = match key.len() {
+        16 => (4, 10),
+        24 => (6, 12),
+        32 => (8, 14),
+        len => {
+            return Err(DecodeError::EncryptedDs2(format!(
+                "unsupported AES key length {len}"
+            )))
+        }
+    };
+
+    for byte in &mut state.blob[AES_STATE_OFFSET..BLOCK_BYTE_INDEX_OFFSET] {
+        *byte = 0;
+    }
+
+    let total_words = 4 * (nr + 1);
+    for i in 0..nk {
+        state.set_round_key_word(i, load_be32(&key[i * 4..i * 4 + 4]));
+    }
+
+    for i in nk..total_words {
+        let mut temp = state.round_key_word(i - 1);
+        if i % nk == 0 {
+            temp = sub_word(rot_word(temp)) ^ AES_RCON[(i / nk) - 1];
+        } else if nk > 6 && i % nk == 4 {
+            temp = sub_word(temp);
+        }
+        let word = state.round_key_word(i - nk) ^ temp;
+        state.set_round_key_word(i, word);
+    }
+
+    state.set_round_count(nr);
+    state.set_flags(0x12);
+    Ok(())
+}
+
+fn aes_decrypt_block(state: &PayloadDecryptState, ciphertext: &[u8]) -> Result<[u8; 16]> {
+    if ciphertext.len() != 16 {
+        return Err(DecodeError::EncryptedDs2(
+            "AES block decrypt requires 16-byte input".to_string(),
+        ));
+    }
+
+    let round_count = state.round_count();
+    let mut block = [0u8; 16];
+    block.copy_from_slice(ciphertext);
+
+    add_round_key(&mut block, state, 4 * round_count);
+
+    for round in (1..round_count).rev() {
+        inv_shift_rows(&mut block);
+        inv_sub_bytes(&mut block);
+        add_round_key(&mut block, state, 4 * round);
+        inv_mix_columns(&mut block);
+    }
+
+    inv_shift_rows(&mut block);
+    inv_sub_bytes(&mut block);
+    add_round_key(&mut block, state, 0);
+
+    Ok(block)
+}
+
+fn add_round_key(state_bytes: &mut [u8; 16], state: &PayloadDecryptState, word_index: usize) {
+    for i in 0..4 {
+        let word = state.round_key_word(word_index + i);
+        state_bytes[4 * i] ^= (word >> 24) as u8;
+        state_bytes[4 * i + 1] ^= (word >> 16) as u8;
+        state_bytes[4 * i + 2] ^= (word >> 8) as u8;
+        state_bytes[4 * i + 3] ^= word as u8;
+    }
+}
+
+fn inv_sub_bytes(state: &mut [u8; 16]) {
+    for byte in state.iter_mut() {
+        *byte = AES_INV_SBOX[*byte as usize];
+    }
+}
+
+fn inv_shift_rows(state: &mut [u8; 16]) {
+    let tmp = *state;
+    state[0] = tmp[0];
+    state[1] = tmp[13];
+    state[2] = tmp[10];
+    state[3] = tmp[7];
+    state[4] = tmp[4];
+    state[5] = tmp[1];
+    state[6] = tmp[14];
+    state[7] = tmp[11];
+    state[8] = tmp[8];
+    state[9] = tmp[5];
+    state[10] = tmp[2];
+    state[11] = tmp[15];
+    state[12] = tmp[12];
+    state[13] = tmp[9];
+    state[14] = tmp[6];
+    state[15] = tmp[3];
+}
+
+fn inv_mix_columns(state: &mut [u8; 16]) {
+    for col in 0..4 {
+        let base = col * 4;
+        let s0 = state[base];
+        let s1 = state[base + 1];
+        let s2 = state[base + 2];
+        let s3 = state[base + 3];
+        state[base] = gf_mul(s0, 14) ^ gf_mul(s1, 11) ^ gf_mul(s2, 13) ^ gf_mul(s3, 9);
+        state[base + 1] = gf_mul(s0, 9) ^ gf_mul(s1, 14) ^ gf_mul(s2, 11) ^ gf_mul(s3, 13);
+        state[base + 2] = gf_mul(s0, 13) ^ gf_mul(s1, 9) ^ gf_mul(s2, 14) ^ gf_mul(s3, 11);
+        state[base + 3] = gf_mul(s0, 11) ^ gf_mul(s1, 13) ^ gf_mul(s2, 9) ^ gf_mul(s3, 14);
+    }
+}
+
+fn gf_mul(mut a: u8, mut b: u8) -> u8 {
+    let mut result = 0u8;
+    while b != 0 {
+        if b & 1 != 0 {
+            result ^= a;
+        }
+        let carry = a & 0x80 != 0;
+        a <<= 1;
+        if carry {
+            a ^= 0x1b;
+        }
+        b >>= 1;
+    }
+    result
+}
+
+fn rot_word(x: u32) -> u32 {
+    x.rotate_left(8)
+}
+
+fn sub_word(x: u32) -> u32 {
+    ((AES_SBOX[((x >> 24) & 0xff) as usize] as u32) << 24)
+        | ((AES_SBOX[((x >> 16) & 0xff) as usize] as u32) << 16)
+        | ((AES_SBOX[((x >> 8) & 0xff) as usize] as u32) << 8)
+        | (AES_SBOX[(x & 0xff) as usize] as u32)
+}
+
+fn load_be32(bytes: &[u8]) -> u32 {
+    u32::from_be_bytes(bytes.try_into().unwrap())
+}
+
+fn store_be32(bytes: &mut [u8], word: u32) {
+    bytes.copy_from_slice(&word.to_be_bytes());
+}
+
+const AES_RCON: [u32; 10] = [
+    0x0100_0000,
+    0x0200_0000,
+    0x0400_0000,
+    0x0800_0000,
+    0x1000_0000,
+    0x2000_0000,
+    0x4000_0000,
+    0x8000_0000,
+    0x1b00_0000,
+    0x3600_0000,
+];
+
+const AES_SBOX: [u8; 256] = [
+    0x63,0x7c,0x77,0x7b,0xf2,0x6b,0x6f,0xc5,0x30,0x01,0x67,0x2b,0xfe,0xd7,0xab,0x76,
+    0xca,0x82,0xc9,0x7d,0xfa,0x59,0x47,0xf0,0xad,0xd4,0xa2,0xaf,0x9c,0xa4,0x72,0xc0,
+    0xb7,0xfd,0x93,0x26,0x36,0x3f,0xf7,0xcc,0x34,0xa5,0xe5,0xf1,0x71,0xd8,0x31,0x15,
+    0x04,0xc7,0x23,0xc3,0x18,0x96,0x05,0x9a,0x07,0x12,0x80,0xe2,0xeb,0x27,0xb2,0x75,
+    0x09,0x83,0x2c,0x1a,0x1b,0x6e,0x5a,0xa0,0x52,0x3b,0xd6,0xb3,0x29,0xe3,0x2f,0x84,
+    0x53,0xd1,0x00,0xed,0x20,0xfc,0xb1,0x5b,0x6a,0xcb,0xbe,0x39,0x4a,0x4c,0x58,0xcf,
+    0xd0,0xef,0xaa,0xfb,0x43,0x4d,0x33,0x85,0x45,0xf9,0x02,0x7f,0x50,0x3c,0x9f,0xa8,
+    0x51,0xa3,0x40,0x8f,0x92,0x9d,0x38,0xf5,0xbc,0xb6,0xda,0x21,0x10,0xff,0xf3,0xd2,
+    0xcd,0x0c,0x13,0xec,0x5f,0x97,0x44,0x17,0xc4,0xa7,0x7e,0x3d,0x64,0x5d,0x19,0x73,
+    0x60,0x81,0x4f,0xdc,0x22,0x2a,0x90,0x88,0x46,0xee,0xb8,0x14,0xde,0x5e,0x0b,0xdb,
+    0xe0,0x32,0x3a,0x0a,0x49,0x06,0x24,0x5c,0xc2,0xd3,0xac,0x62,0x91,0x95,0xe4,0x79,
+    0xe7,0xc8,0x37,0x6d,0x8d,0xd5,0x4e,0xa9,0x6c,0x56,0xf4,0xea,0x65,0x7a,0xae,0x08,
+    0xba,0x78,0x25,0x2e,0x1c,0xa6,0xb4,0xc6,0xe8,0xdd,0x74,0x1f,0x4b,0xbd,0x8b,0x8a,
+    0x70,0x3e,0xb5,0x66,0x48,0x03,0xf6,0x0e,0x61,0x35,0x57,0xb9,0x86,0xc1,0x1d,0x9e,
+    0xe1,0xf8,0x98,0x11,0x69,0xd9,0x8e,0x94,0x9b,0x1e,0x87,0xe9,0xce,0x55,0x28,0xdf,
+    0x8c,0xa1,0x89,0x0d,0xbf,0xe6,0x42,0x68,0x41,0x99,0x2d,0x0f,0xb0,0x54,0xbb,0x16,
+];
+
+const AES_INV_SBOX: [u8; 256] = [
+    0x52,0x09,0x6a,0xd5,0x30,0x36,0xa5,0x38,0xbf,0x40,0xa3,0x9e,0x81,0xf3,0xd7,0xfb,
+    0x7c,0xe3,0x39,0x82,0x9b,0x2f,0xff,0x87,0x34,0x8e,0x43,0x44,0xc4,0xde,0xe9,0xcb,
+    0x54,0x7b,0x94,0x32,0xa6,0xc2,0x23,0x3d,0xee,0x4c,0x95,0x0b,0x42,0xfa,0xc3,0x4e,
+    0x08,0x2e,0xa1,0x66,0x28,0xd9,0x24,0xb2,0x76,0x5b,0xa2,0x49,0x6d,0x8b,0xd1,0x25,
+    0x72,0xf8,0xf6,0x64,0x86,0x68,0x98,0x16,0xd4,0xa4,0x5c,0xcc,0x5d,0x65,0xb6,0x92,
+    0x6c,0x70,0x48,0x50,0xfd,0xed,0xb9,0xda,0x5e,0x15,0x46,0x57,0xa7,0x8d,0x9d,0x84,
+    0x90,0xd8,0xab,0x00,0x8c,0xbc,0xd3,0x0a,0xf7,0xe4,0x58,0x05,0xb8,0xb3,0x45,0x06,
+    0xd0,0x2c,0x1e,0x8f,0xca,0x3f,0x0f,0x02,0xc1,0xaf,0xbd,0x03,0x01,0x13,0x8a,0x6b,
+    0x3a,0x91,0x11,0x41,0x4f,0x67,0xdc,0xea,0x97,0xf2,0xcf,0xce,0xf0,0xb4,0xe6,0x73,
+    0x96,0xac,0x74,0x22,0xe7,0xad,0x35,0x85,0xe2,0xf9,0x37,0xe8,0x1c,0x75,0xdf,0x6e,
+    0x47,0xf1,0x1a,0x71,0x1d,0x29,0xc5,0x89,0x6f,0xb7,0x62,0x0e,0xaa,0x18,0xbe,0x1b,
+    0xfc,0x56,0x3e,0x4b,0xc6,0xd2,0x79,0x20,0x9a,0xdb,0xc0,0xfe,0x78,0xcd,0x5a,0xf4,
+    0x1f,0xdd,0xa8,0x33,0x88,0x07,0xc7,0x31,0xb1,0x12,0x10,0x59,0x27,0x80,0xec,0x5f,
+    0x60,0x51,0x7f,0xa9,0x19,0xb5,0x4a,0x0d,0x2d,0xe5,0x7a,0x9f,0x93,0xc9,0x9c,0xef,
+    0xa0,0xe0,0x3b,0x4d,0xae,0x2a,0xf5,0xb0,0xc8,0xeb,0xbb,0x3c,0x83,0x53,0x99,0x61,
+    0x17,0x2b,0x04,0x7e,0xba,0x77,0xd6,0x26,0xe1,0x69,0x14,0x63,0x55,0x21,0x0c,0x7d,
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DESC_128: [u8; 22] = [
+        0x01, 0x00, 0xEA, 0x89, 0x41, 0x86, 0x20, 0x9E, 0x20, 0xF3, 0xCD, 0x63, 0xF4, 0xD9,
+        0x34, 0xF0, 0xD3, 0x8D, 0x10, 0xC9, 0xD2, 0x06,
+    ];
+    const DESC_256: [u8; 22] = [
+        0x02, 0x00, 0x23, 0xBC, 0xB6, 0xA9, 0x99, 0x81, 0x20, 0x83, 0x39, 0xF3, 0xA4, 0xC3,
+        0xBF, 0x41, 0xEE, 0x5A, 0xA7, 0xA8, 0x2A, 0x12,
+    ];
+
+    #[test]
+    fn parse_descriptor_128() {
+        let mut header = [0u8; DS2_HEADER_SIZE];
+        header[DECRYPT_DESCRIPTOR_OFFSET..DECRYPT_DESCRIPTOR_OFFSET + DECRYPT_DESCRIPTOR_SIZE]
+            .copy_from_slice(&DESC_128);
+        let desc = parse_decrypt_descriptor(&header).unwrap();
+        assert_eq!(desc.key_mode, KeyMode::Aes128);
+        assert_eq!(desc.expected_check_word, 0xC910);
+        assert_eq!(
+            desc.aux_16,
+            [
+                0xEA, 0x89, 0x41, 0x86, 0x20, 0x9E, 0x20, 0xF3, 0xCD, 0x63, 0xF4, 0xD9, 0x34,
+                0xF0, 0xD3, 0x8D
+            ]
+        );
+    }
+
+    #[test]
+    fn derive_128_matches_known_sample_descriptor() {
+        let (_, check) = derive_key_128(b"1234", &[
+            0xEA, 0x89, 0x41, 0x86, 0x20, 0x9E, 0x20, 0xF3, 0xCD, 0x63, 0xF4, 0xD9, 0x34,
+            0xF0, 0xD3, 0x8D,
+        ]).unwrap();
+        assert_eq!(check, 0xC910);
+    }
+
+    #[test]
+    fn derive_256_matches_known_sample_descriptor() {
+        let (_, check) = derive_key_256(b"1234", &[
+            0x23, 0xBC, 0xB6, 0xA9, 0x99, 0x81, 0x20, 0x83, 0x39, 0xF3, 0xA4, 0xC3, 0xBF,
+            0x41, 0xEE, 0x5A,
+        ]).unwrap();
+        assert_eq!(check, 0xA8A7);
+    }
+
+    #[test]
+    fn build_saved_state_accepts_known_128_password() {
+        let mut header = [0u8; DS2_HEADER_SIZE];
+        header[DECRYPT_DESCRIPTOR_OFFSET..DECRYPT_DESCRIPTOR_OFFSET + DECRYPT_DESCRIPTOR_SIZE]
+            .copy_from_slice(&DESC_128);
+        let desc = parse_decrypt_descriptor(&header).unwrap();
+        build_saved_state(b"1234", &desc).unwrap();
+    }
+
+    #[test]
+    fn build_saved_state_accepts_known_256_password() {
+        let mut header = [0u8; DS2_HEADER_SIZE];
+        header[DECRYPT_DESCRIPTOR_OFFSET..DECRYPT_DESCRIPTOR_OFFSET + DECRYPT_DESCRIPTOR_SIZE]
+            .copy_from_slice(&DESC_256);
+        let desc = parse_decrypt_descriptor(&header).unwrap();
+        build_saved_state(b"1234", &desc).unwrap();
+    }
+}

--- a/dss-codec/src/crypto/mod.rs
+++ b/dss-codec/src/crypto/mod.rs
@@ -1,0 +1,1 @@
+pub mod ds2_encrypted;

--- a/dss-codec/src/demux/ds2.rs
+++ b/dss-codec/src/demux/ds2.rs
@@ -3,11 +3,11 @@
 /// SP mode (0-1): byte-swap demuxing, returns list of 42-byte packets.
 /// QP mode (6-7): continuous bitstream, returns raw byte stream + frame count.
 use crate::error::{DecodeError, Result};
-
 const DS2_HEADER_SIZE: usize = 0x600;
 const DS2_BLOCK_SIZE: usize = 512;
 const DS2_BLOCK_HEADER_SIZE: usize = 6;
 const DSS_SP_PACKET_SIZE: usize = 42;
+const DS2_QP_FRAME_SIZE: usize = 56;
 
 /// Demux a DS2 file.
 /// Returns (frame_data, total_frames, is_qp).
@@ -31,9 +31,8 @@ pub fn demux_ds2(data: &[u8]) -> Result<DemuxedDs2> {
         let mut stream = Vec::new();
         for bi in 0..num_blocks {
             let bstart = DS2_HEADER_SIZE + bi * DS2_BLOCK_SIZE;
-            stream.extend_from_slice(
-                &data[bstart + DS2_BLOCK_HEADER_SIZE..bstart + DS2_BLOCK_SIZE],
-            );
+            stream
+                .extend_from_slice(&data[bstart + DS2_BLOCK_HEADER_SIZE..bstart + DS2_BLOCK_SIZE]);
         }
         Ok(DemuxedDs2::Qp {
             stream,
@@ -44,9 +43,8 @@ pub fn demux_ds2(data: &[u8]) -> Result<DemuxedDs2> {
         let mut stream = Vec::new();
         for bi in 0..num_blocks {
             let bstart = DS2_HEADER_SIZE + bi * DS2_BLOCK_SIZE;
-            stream.extend_from_slice(
-                &data[bstart + DS2_BLOCK_HEADER_SIZE..bstart + DS2_BLOCK_SIZE],
-            );
+            stream
+                .extend_from_slice(&data[bstart + DS2_BLOCK_HEADER_SIZE..bstart + DS2_BLOCK_SIZE]);
         }
 
         let mut swap = ((data[DS2_HEADER_SIZE] >> 7) & 1) as usize;
@@ -95,4 +93,315 @@ pub enum DemuxedDs2 {
         stream: Vec<u8>,
         total_frames: usize,
     },
+}
+
+pub(crate) struct Ds2SpStreamDemuxer {
+    header_complete: bool,
+    block_buf: Vec<u8>,
+    stream_buf: Vec<u8>,
+    pending_frames: usize,
+    swap: usize,
+    swap_byte: u8,
+    have_initial_swap: bool,
+}
+
+impl Ds2SpStreamDemuxer {
+    pub(crate) fn new() -> Self {
+        Self {
+            header_complete: false,
+            block_buf: Vec::new(),
+            stream_buf: Vec::new(),
+            pending_frames: 0,
+            swap: 0,
+            swap_byte: 0,
+            have_initial_swap: false,
+        }
+    }
+
+    pub(crate) fn push(&mut self, data: &[u8]) -> Result<Vec<Vec<u8>>> {
+        let mut frames = Vec::new();
+        let mut offset = 0;
+
+        if !self.header_complete {
+            let needed = DS2_HEADER_SIZE.saturating_sub(self.block_buf.len());
+            let take = needed.min(data.len());
+            self.block_buf.extend_from_slice(&data[..take]);
+            offset += take;
+            if self.block_buf.len() < DS2_HEADER_SIZE {
+                return Ok(frames);
+            }
+            self.header_complete = true;
+            self.block_buf.clear();
+        }
+
+        self.block_buf.extend_from_slice(&data[offset..]);
+        while self.block_buf.len() >= DS2_BLOCK_SIZE {
+            let block: Vec<u8> = self.block_buf.drain(..DS2_BLOCK_SIZE).collect();
+            self.process_block(&block, &mut frames);
+        }
+
+        Ok(frames)
+    }
+
+    pub(crate) fn finish(&mut self) -> Result<Vec<Vec<u8>>> {
+        if !self.header_complete {
+            if self.block_buf.is_empty() {
+                return Ok(Vec::new());
+            }
+            return Err(DecodeError::Truncated("DS2 header".to_string()));
+        }
+        if !self.block_buf.is_empty() {
+            return Err(DecodeError::Truncated("DS2 block".to_string()));
+        }
+        if self.pending_frames > 0 {
+            return Err(DecodeError::Truncated("DS2 SP frame".to_string()));
+        }
+        Ok(Vec::new())
+    }
+
+    pub(crate) fn finish_lenient(&mut self) -> Result<Vec<Vec<u8>>> {
+        if !self.header_complete {
+            if self.block_buf.is_empty() {
+                return Ok(Vec::new());
+            }
+            return Err(DecodeError::Truncated("DS2 header".to_string()));
+        }
+
+        self.block_buf.clear();
+
+        let mut frames = Vec::with_capacity(self.pending_frames);
+        while self.pending_frames > 0 {
+            let needed = if self.swap != 0 {
+                40
+            } else {
+                DSS_SP_PACKET_SIZE
+            };
+            frames.push(self.extract_sp_packet_padded(needed));
+            self.pending_frames -= 1;
+        }
+
+        Ok(frames)
+    }
+
+    fn process_block(&mut self, block: &[u8], frames: &mut Vec<Vec<u8>>) {
+        if !self.have_initial_swap {
+            self.swap = ((block[0] >> 7) & 1) as usize;
+            self.have_initial_swap = true;
+        }
+        self.pending_frames += block[2] as usize;
+        self.stream_buf
+            .extend_from_slice(&block[DS2_BLOCK_HEADER_SIZE..DS2_BLOCK_SIZE]);
+
+        while self.pending_frames > 0 {
+            let needed = if self.swap != 0 {
+                40
+            } else {
+                DSS_SP_PACKET_SIZE
+            };
+            if self.stream_buf.len() < needed {
+                break;
+            }
+            frames.push(self.extract_sp_packet(needed));
+            self.pending_frames -= 1;
+        }
+    }
+
+    fn extract_sp_packet(&mut self, read_size: usize) -> Vec<u8> {
+        let mut pkt = [0u8; DSS_SP_PACKET_SIZE + 1];
+        let chunk: Vec<u8> = self.stream_buf.drain(..read_size).collect();
+        self.fill_sp_packet(&mut pkt, &chunk);
+        pkt[..DSS_SP_PACKET_SIZE].to_vec()
+    }
+
+    fn extract_sp_packet_padded(&mut self, read_size: usize) -> Vec<u8> {
+        let take = read_size.min(self.stream_buf.len());
+        let chunk: Vec<u8> = self.stream_buf.drain(..take).collect();
+        let mut pkt = [0u8; DSS_SP_PACKET_SIZE + 1];
+        self.fill_sp_packet(&mut pkt, &chunk);
+        pkt[..DSS_SP_PACKET_SIZE].to_vec()
+    }
+
+    fn fill_sp_packet(&mut self, pkt: &mut [u8; DSS_SP_PACKET_SIZE + 1], chunk: &[u8]) {
+        if self.swap != 0 {
+            pkt[3..3 + chunk.len()].copy_from_slice(chunk);
+            for i in (0..DSS_SP_PACKET_SIZE - 2).step_by(2) {
+                pkt[i] = pkt[i + 4];
+            }
+            pkt[DSS_SP_PACKET_SIZE] = 0;
+            pkt[1] = self.swap_byte;
+        } else {
+            pkt[..chunk.len()].copy_from_slice(chunk);
+            self.swap_byte = pkt[DSS_SP_PACKET_SIZE - 2];
+        }
+        pkt[DSS_SP_PACKET_SIZE - 2] = 0;
+        self.swap ^= 1;
+    }
+}
+
+pub(crate) struct Ds2QpStreamDemuxer {
+    header_complete: bool,
+    block_buf: Vec<u8>,
+    stream_buf: Vec<u8>,
+    pending_frames: usize,
+}
+
+impl Ds2QpStreamDemuxer {
+    pub(crate) fn new() -> Self {
+        Self {
+            header_complete: false,
+            block_buf: Vec::new(),
+            stream_buf: Vec::new(),
+            pending_frames: 0,
+        }
+    }
+
+    pub(crate) fn push(&mut self, data: &[u8]) -> Result<Vec<Vec<u8>>> {
+        let mut frames = Vec::new();
+        let mut offset = 0;
+
+        if !self.header_complete {
+            let needed = DS2_HEADER_SIZE.saturating_sub(self.block_buf.len());
+            let take = needed.min(data.len());
+            self.block_buf.extend_from_slice(&data[..take]);
+            offset += take;
+            if self.block_buf.len() < DS2_HEADER_SIZE {
+                return Ok(frames);
+            }
+            self.header_complete = true;
+            self.block_buf.clear();
+        }
+
+        self.block_buf.extend_from_slice(&data[offset..]);
+        while self.block_buf.len() >= DS2_BLOCK_SIZE {
+            let block: Vec<u8> = self.block_buf.drain(..DS2_BLOCK_SIZE).collect();
+            self.process_block(&block, &mut frames);
+        }
+
+        Ok(frames)
+    }
+
+    pub(crate) fn finish(&mut self) -> Result<Vec<Vec<u8>>> {
+        if !self.header_complete {
+            if self.block_buf.is_empty() {
+                return Ok(Vec::new());
+            }
+            return Err(DecodeError::Truncated("DS2 header".to_string()));
+        }
+        if !self.block_buf.is_empty() {
+            return Err(DecodeError::Truncated("DS2 block".to_string()));
+        }
+        if self.pending_frames > 0 {
+            return Err(DecodeError::Truncated("DS2 QP frame".to_string()));
+        }
+        Ok(Vec::new())
+    }
+
+    pub(crate) fn finish_lenient(&mut self) -> Result<Vec<Vec<u8>>> {
+        if !self.header_complete {
+            if self.block_buf.is_empty() {
+                return Ok(Vec::new());
+            }
+            return Err(DecodeError::Truncated("DS2 header".to_string()));
+        }
+
+        self.block_buf.clear();
+
+        let mut frames = Vec::with_capacity(self.pending_frames);
+        while self.pending_frames > 0 {
+            let take = DS2_QP_FRAME_SIZE.min(self.stream_buf.len());
+            let mut frame = vec![0u8; DS2_QP_FRAME_SIZE];
+            let chunk: Vec<u8> = self.stream_buf.drain(..take).collect();
+            frame[..chunk.len()].copy_from_slice(&chunk);
+            frames.push(frame);
+            self.pending_frames -= 1;
+        }
+
+        Ok(frames)
+    }
+
+    fn process_block(&mut self, block: &[u8], frames: &mut Vec<Vec<u8>>) {
+        self.pending_frames += block[2] as usize;
+        self.stream_buf
+            .extend_from_slice(&block[DS2_BLOCK_HEADER_SIZE..DS2_BLOCK_SIZE]);
+
+        while self.pending_frames > 0 && self.stream_buf.len() >= DS2_QP_FRAME_SIZE {
+            let frame: Vec<u8> = self.stream_buf.drain(..DS2_QP_FRAME_SIZE).collect();
+            frames.push(frame);
+            self.pending_frames -= 1;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_ds2_file(mode: u8, frame_count: u8, payload_pattern: u8) -> Vec<u8> {
+        let mut data = vec![0u8; DS2_HEADER_SIZE];
+        data[..4].copy_from_slice(b"\x03ds2");
+
+        let mut block = [0u8; DS2_BLOCK_SIZE];
+        block[2] = frame_count;
+        block[4] = mode;
+        for (i, byte) in block[DS2_BLOCK_HEADER_SIZE..].iter_mut().enumerate() {
+            *byte = payload_pattern.wrapping_add(i as u8);
+        }
+
+        data.extend_from_slice(&block);
+        data
+    }
+
+    #[test]
+    fn test_ds2_sp_stream_demux_matches_batch() {
+        let data = make_ds2_file(0, 4, 0x10);
+        let expected = match demux_ds2(&data).unwrap() {
+            DemuxedDs2::Sp { packets, .. } => packets,
+            _ => panic!("expected DS2 SP packets"),
+        };
+
+        let mut demuxer = Ds2SpStreamDemuxer::new();
+        let mut actual = Vec::new();
+        for chunk in data.chunks(137) {
+            actual.extend(demuxer.push(chunk).unwrap());
+        }
+        actual.extend(demuxer.finish().unwrap());
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_ds2_qp_stream_demux_matches_batch() {
+        let data = make_ds2_file(6, 3, 0x40);
+        let expected = match demux_ds2(&data).unwrap() {
+            DemuxedDs2::Qp {
+                stream,
+                total_frames,
+            } => stream[..total_frames * DS2_QP_FRAME_SIZE]
+                .chunks(DS2_QP_FRAME_SIZE)
+                .map(|chunk| chunk.to_vec())
+                .collect::<Vec<_>>(),
+            _ => panic!("expected DS2 QP stream"),
+        };
+
+        let mut demuxer = Ds2QpStreamDemuxer::new();
+        let mut actual = Vec::new();
+        for chunk in data.chunks(113) {
+            actual.extend(demuxer.push(chunk).unwrap());
+        }
+        actual.extend(demuxer.finish().unwrap());
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_ds2_qp_stream_demux_truncated_frame() {
+        let data = make_ds2_file(6, 10, 0x55);
+        let mut demuxer = Ds2QpStreamDemuxer::new();
+        for chunk in data.chunks(97) {
+            let _ = demuxer.push(chunk).unwrap();
+        }
+
+        let err = demuxer.finish().unwrap_err();
+        assert!(matches!(err, DecodeError::Truncated(_)));
+    }
 }

--- a/dss-codec/src/demux/dss.rs
+++ b/dss-codec/src/demux/dss.rs
@@ -3,6 +3,7 @@
 /// Handles empty blocks (frame_count=0) by only including continuation bytes
 /// from empty block payloads, and resetting swap state at block group boundaries.
 use crate::error::{DecodeError, Result};
+use std::collections::VecDeque;
 
 const DSS_BLOCK_SIZE: usize = 512;
 const DSS_BLOCK_HEADER_SIZE: usize = 6;
@@ -106,4 +107,307 @@ pub fn demux_dss(data: &[u8]) -> Result<(Vec<Vec<u8>>, usize)> {
     }
 
     Ok((frame_packets, total_frames))
+}
+
+pub(crate) struct DssSpStreamDemuxer {
+    header_size: usize,
+    header_complete: bool,
+    block_buf: Vec<u8>,
+    stream_buf: Vec<u8>,
+    stream_pos: usize,
+    pending_frames: usize,
+    swap: usize,
+    swap_byte: u8,
+    have_initial_swap: bool,
+    stream_end_pos: usize,
+    pending_reset_positions: Vec<usize>,
+    scheduled_resets: VecDeque<(usize, usize)>,
+}
+
+impl DssSpStreamDemuxer {
+    pub(crate) fn new(version: u8) -> Self {
+        Self {
+            header_size: version as usize * DSS_BLOCK_SIZE,
+            header_complete: false,
+            block_buf: Vec::new(),
+            stream_buf: Vec::new(),
+            stream_pos: 0,
+            pending_frames: 0,
+            swap: 0,
+            swap_byte: 0,
+            have_initial_swap: false,
+            stream_end_pos: 0,
+            pending_reset_positions: Vec::new(),
+            scheduled_resets: VecDeque::new(),
+        }
+    }
+
+    pub(crate) fn push(&mut self, data: &[u8]) -> Result<Vec<Vec<u8>>> {
+        let mut frames = Vec::new();
+        let mut offset = 0;
+
+        if !self.header_complete {
+            let needed = self.header_size.saturating_sub(self.block_buf.len());
+            let take = needed.min(data.len());
+            self.block_buf.extend_from_slice(&data[..take]);
+            offset += take;
+            if self.block_buf.len() < self.header_size {
+                return Ok(frames);
+            }
+            self.header_complete = true;
+            self.block_buf.clear();
+        }
+
+        self.block_buf.extend_from_slice(&data[offset..]);
+        while self.block_buf.len() >= DSS_BLOCK_SIZE {
+            let block: Vec<u8> = self.block_buf.drain(..DSS_BLOCK_SIZE).collect();
+            self.process_block(&block, &mut frames);
+        }
+
+        Ok(frames)
+    }
+
+    pub(crate) fn finish(&mut self) -> Result<Vec<Vec<u8>>> {
+        if !self.header_complete {
+            if self.block_buf.is_empty() {
+                return Ok(Vec::new());
+            }
+            return Err(DecodeError::Truncated("DSS header".to_string()));
+        }
+        if !self.block_buf.is_empty() {
+            return Err(DecodeError::Truncated("DSS block".to_string()));
+        }
+        if self.pending_frames > 0 {
+            return Err(DecodeError::Truncated("DSS SP frame".to_string()));
+        }
+        Ok(Vec::new())
+    }
+
+    pub(crate) fn finish_lenient(&mut self) -> Result<Vec<Vec<u8>>> {
+        if !self.header_complete {
+            if self.block_buf.is_empty() {
+                return Ok(Vec::new());
+            }
+            return Err(DecodeError::Truncated("DSS header".to_string()));
+        }
+
+        self.block_buf.clear();
+
+        let mut frames = Vec::with_capacity(self.pending_frames);
+        while self.pending_frames > 0 {
+            while let Some(&(reset_pos, new_swap)) = self.scheduled_resets.front() {
+                if self.stream_pos != reset_pos {
+                    break;
+                }
+                self.swap = new_swap;
+                self.swap_byte = 0;
+                self.scheduled_resets.pop_front();
+            }
+
+            let needed = if self.swap != 0 { 40 } else { DSS_SP_FRAME_SIZE };
+            frames.push(self.extract_packet_padded(needed));
+            self.pending_frames -= 1;
+            self.compact_stream();
+        }
+
+        Ok(frames)
+    }
+
+    fn process_block(&mut self, block: &[u8], frames: &mut Vec<Vec<u8>>) {
+        let byte0 = block[0];
+        let byte1 = block[1] as usize;
+        let frame_count = block[2] as usize;
+        let blk_swap = ((byte0 >> 7) & 1) as usize;
+        let cont_size = (2 * byte1 + 2 * blk_swap).saturating_sub(DSS_BLOCK_HEADER_SIZE);
+        let payload = &block[DSS_BLOCK_HEADER_SIZE..];
+
+        if !self.have_initial_swap {
+            self.swap = blk_swap;
+            self.have_initial_swap = true;
+        }
+
+        if frame_count == 0 {
+            let cs = cont_size.min(payload.len());
+            self.stream_buf.extend_from_slice(&payload[..cs]);
+            self.stream_end_pos += cs;
+            self.pending_reset_positions.push(self.stream_end_pos);
+        } else {
+            if !self.pending_reset_positions.is_empty() {
+                for pos in self.pending_reset_positions.drain(..) {
+                    self.scheduled_resets.push_back((pos, blk_swap));
+                }
+            }
+            self.stream_buf.extend_from_slice(payload);
+            self.stream_end_pos += payload.len();
+            self.pending_frames += frame_count;
+        }
+
+        self.emit_available_frames(frames);
+    }
+
+    fn emit_available_frames(&mut self, frames: &mut Vec<Vec<u8>>) {
+        while self.pending_frames > 0 {
+            while let Some(&(reset_pos, new_swap)) = self.scheduled_resets.front() {
+                if self.stream_pos != reset_pos {
+                    break;
+                }
+                self.swap = new_swap;
+                self.swap_byte = 0;
+                self.scheduled_resets.pop_front();
+            }
+
+            let needed = if self.swap != 0 {
+                40
+            } else {
+                DSS_SP_FRAME_SIZE
+            };
+            if self.available_stream() < needed {
+                break;
+            }
+
+            frames.push(self.extract_packet(needed));
+            self.pending_frames -= 1;
+            self.compact_stream();
+        }
+    }
+
+    fn extract_packet(&mut self, read_size: usize) -> Vec<u8> {
+        let mut pkt = [0u8; DSS_SP_FRAME_SIZE + 1];
+        let end = self.stream_pos + read_size;
+        let chunk = self.stream_buf[self.stream_pos..end].to_vec();
+        self.fill_packet(&mut pkt, chunk);
+        self.stream_pos = end;
+        pkt[..DSS_SP_FRAME_SIZE].to_vec()
+    }
+
+    fn extract_packet_padded(&mut self, read_size: usize) -> Vec<u8> {
+        let take = read_size.min(self.available_stream());
+        let end = self.stream_pos + take;
+        let chunk = self.stream_buf[self.stream_pos..end].to_vec();
+        let mut pkt = [0u8; DSS_SP_FRAME_SIZE + 1];
+        self.fill_packet(&mut pkt, chunk);
+        self.stream_pos = end;
+        pkt[..DSS_SP_FRAME_SIZE].to_vec()
+    }
+
+    fn fill_packet(&mut self, pkt: &mut [u8; DSS_SP_FRAME_SIZE + 1], chunk: Vec<u8>) {
+        if self.swap != 0 {
+            pkt[3..3 + chunk.len()].copy_from_slice(&chunk);
+            for i in (0..DSS_SP_FRAME_SIZE - 2).step_by(2) {
+                pkt[i] = pkt[i + 4];
+            }
+            pkt[DSS_SP_FRAME_SIZE] = 0;
+            pkt[1] = self.swap_byte;
+        } else {
+            pkt[..chunk.len()].copy_from_slice(&chunk);
+            self.swap_byte = pkt[DSS_SP_FRAME_SIZE - 2];
+        }
+        pkt[DSS_SP_FRAME_SIZE - 2] = 0;
+        self.swap ^= 1;
+    }
+
+    fn available_stream(&self) -> usize {
+        self.stream_buf.len().saturating_sub(self.stream_pos)
+    }
+
+    fn compact_stream(&mut self) {
+        if self.stream_pos == 0 {
+            return;
+        }
+        if self.stream_pos >= self.stream_buf.len() {
+            self.stream_buf.clear();
+            self.stream_pos = 0;
+            return;
+        }
+        self.stream_buf.drain(..self.stream_pos);
+        let consumed = self.stream_pos;
+        self.stream_pos = 0;
+        for pos in &mut self.pending_reset_positions {
+            *pos = pos.saturating_sub(consumed);
+        }
+        for (pos, _) in &mut self.scheduled_resets {
+            *pos = pos.saturating_sub(consumed);
+        }
+        self.stream_end_pos = self.stream_end_pos.saturating_sub(consumed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_dss_block(
+        swap: u8,
+        byte1: u8,
+        frame_count: u8,
+        payload_pattern: u8,
+    ) -> [u8; DSS_BLOCK_SIZE] {
+        let mut block = [0u8; DSS_BLOCK_SIZE];
+        block[0] = swap << 7;
+        block[1] = byte1;
+        block[2] = frame_count;
+        for (i, byte) in block[DSS_BLOCK_HEADER_SIZE..].iter_mut().enumerate() {
+            *byte = payload_pattern.wrapping_add(i as u8);
+        }
+        block
+    }
+
+    fn collect_frames(
+        demuxer: &mut DssSpStreamDemuxer,
+        data: &[u8],
+        chunk_size: usize,
+    ) -> Vec<Vec<u8>> {
+        let mut frames = Vec::new();
+        for chunk in data.chunks(chunk_size) {
+            frames.extend(demuxer.push(chunk).unwrap());
+        }
+        frames.extend(demuxer.finish().unwrap());
+        frames
+    }
+
+    #[test]
+    fn test_dss_stream_demux_matches_batch() {
+        let mut data = vec![0u8; 2 * DSS_BLOCK_SIZE];
+        data[0] = 2;
+        data[1..4].copy_from_slice(b"dss");
+        data.extend_from_slice(&make_dss_block(0, 0, 3, 0x20));
+
+        let (expected, _) = demux_dss(&data).unwrap();
+        let mut demuxer = DssSpStreamDemuxer::new(2);
+        let actual = collect_frames(&mut demuxer, &data, 149);
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_dss_stream_demux_empty_block_reset_matches_batch() {
+        let mut data = vec![0u8; 2 * DSS_BLOCK_SIZE];
+        data[0] = 2;
+        data[1..4].copy_from_slice(b"dss");
+        data.extend_from_slice(&make_dss_block(0, 0, 13, 0x10));
+        data.extend_from_slice(&make_dss_block(1, 17, 0, 0x80));
+        data.extend_from_slice(&make_dss_block(1, 0, 1, 0xC0));
+
+        let (expected, _) = demux_dss(&data).unwrap();
+        let mut demuxer = DssSpStreamDemuxer::new(2);
+        let actual = collect_frames(&mut demuxer, &data, 127);
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_dss_stream_demux_truncated_frame() {
+        let mut data = vec![0u8; 2 * DSS_BLOCK_SIZE];
+        data[0] = 2;
+        data[1..4].copy_from_slice(b"dss");
+        data.extend_from_slice(&make_dss_block(0, 0, 20, 0x30));
+
+        let mut demuxer = DssSpStreamDemuxer::new(2);
+        for chunk in data.chunks(211) {
+            let _ = demuxer.push(chunk).unwrap();
+        }
+
+        let err = demuxer.finish().unwrap_err();
+        assert!(matches!(err, DecodeError::Truncated(_)));
+    }
 }

--- a/dss-codec/src/error.rs
+++ b/dss-codec/src/error.rs
@@ -14,6 +14,9 @@ pub enum DecodeError {
     #[error("unsupported DS2 format type: {0}")]
     UnsupportedFormat(u8),
 
+    #[error("encrypted DS2 error: {0}")]
+    EncryptedDs2(String),
+
     #[error("bitstream exhausted: needed {needed} bits, {available} available")]
     BitstreamExhausted { needed: usize, available: usize },
 

--- a/dss-codec/src/error.rs
+++ b/dss-codec/src/error.rs
@@ -20,6 +20,12 @@ pub enum DecodeError {
     #[error("invalid frame data at frame {frame}: {detail}")]
     InvalidFrame { frame: usize, detail: String },
 
+    #[error("truncated data: {0}")]
+    Truncated(String),
+
+    #[error("streaming decoder is already finished")]
+    AlreadyFinished,
+
     #[error("WAV write error: {0}")]
     Wav(#[from] hound::Error),
 

--- a/dss-codec/src/lib.rs
+++ b/dss-codec/src/lib.rs
@@ -1,11 +1,13 @@
 pub mod bitstream;
 pub mod codec;
+pub mod crypto;
 pub mod demux;
 pub mod error;
 pub mod output;
 pub mod streaming;
 pub mod tables;
 
+use crate::crypto::ds2_encrypted::{decrypt_encrypted_ds2, ENCRYPTED_MAGIC};
 use crate::demux::{detect_format, AudioFormat};
 use crate::error::{DecodeError, Result};
 use crate::output::resample::resample;
@@ -13,6 +15,7 @@ use crate::output::wav::write_wav;
 use crate::output::OutputConfig;
 use crate::streaming::StreamingDecoder;
 
+use std::borrow::Cow;
 use std::path::Path;
 
 /// Decoded audio buffer
@@ -27,26 +30,48 @@ pub struct AudioBuffer {
 
 /// Decode a DSS/DS2 file to an AudioBuffer.
 pub fn decode_file(path: &Path) -> Result<AudioBuffer> {
+    decode_file_with_password(path, None)
+}
+
+/// Decode a DSS/DS2 file to an AudioBuffer, optionally decrypting encrypted DS2 input first.
+pub fn decode_file_with_password(path: &Path, password: Option<&[u8]>) -> Result<AudioBuffer> {
     let data = std::fs::read(path)?;
-    decode_to_buffer(&data)
+    decode_to_buffer_with_password(&data, password)
 }
 
 /// Decode raw file bytes to an AudioBuffer.
 pub fn decode_to_buffer(data: &[u8]) -> Result<AudioBuffer> {
+    decode_to_buffer_with_password(data, None)
+}
+
+/// Decode raw file bytes to an AudioBuffer, optionally decrypting encrypted DS2 input first.
+pub fn decode_to_buffer_with_password(data: &[u8], password: Option<&[u8]>) -> Result<AudioBuffer> {
+    let prepared = prepare_decode_bytes(data, password)?;
     let mut decoder = StreamingDecoder::new();
-    let mut samples = decoder.push(data)?;
+    let mut samples = decoder.push(&prepared)?;
     samples.extend(decoder.finish_lenient()?);
 
     let format = decoder
         .format()
-        .or_else(|| detect_format(data))
-        .ok_or_else(|| DecodeError::UnsupportedFormat(data.first().copied().unwrap_or(0)))?;
+        .or_else(|| detect_format(&prepared))
+        .ok_or_else(|| DecodeError::UnsupportedFormat(prepared.first().copied().unwrap_or(0)))?;
 
     Ok(AudioBuffer {
         samples,
         native_rate: format.native_sample_rate(),
         format,
     })
+}
+
+fn prepare_decode_bytes<'a>(data: &'a [u8], password: Option<&[u8]>) -> Result<Cow<'a, [u8]>> {
+    if data.starts_with(&ENCRYPTED_MAGIC) {
+        let password = password.ok_or_else(|| {
+            DecodeError::EncryptedDs2("password required for encrypted DS2 input".to_string())
+        })?;
+        let decrypted = decrypt_encrypted_ds2(data, password)?;
+        return Ok(Cow::Owned(decrypted));
+    }
+    Ok(Cow::Borrowed(data))
 }
 
 #[cfg(test)]
@@ -57,7 +82,6 @@ mod tests {
     use crate::codec::ds2_qp::Ds2QpDecoder;
     use crate::demux::ds2::{demux_ds2, DemuxedDs2};
     use crate::demux::dss::demux_dss;
-
     fn make_truncated_ds2_qp_file(frame_count: u8) -> Vec<u8> {
         let mut data = vec![0u8; 0x600];
         data[..4].copy_from_slice(b"\x03ds2");
@@ -181,7 +205,16 @@ mod tests {
 
 /// Decode a file and write to WAV with given output configuration.
 pub fn decode_and_write(input: &Path, output: &Path, config: &OutputConfig) -> Result<AudioBuffer> {
-    let mut buf = decode_file(input)?;
+    decode_and_write_with_password(input, output, config, None)
+}
+
+pub fn decode_and_write_with_password(
+    input: &Path,
+    output: &Path,
+    config: &OutputConfig,
+    password: Option<&[u8]>,
+) -> Result<AudioBuffer> {
+    let mut buf = decode_file_with_password(input, password)?;
 
     let target_rate = config.sample_rate.unwrap_or(buf.native_rate);
 

--- a/dss-codec/src/lib.rs
+++ b/dss-codec/src/lib.rs
@@ -3,18 +3,15 @@ pub mod codec;
 pub mod demux;
 pub mod error;
 pub mod output;
+pub mod streaming;
 pub mod tables;
 
-use crate::codec::ds2_qp::Ds2QpDecoder;
-use crate::codec::ds2_sp::Ds2SpDecoder;
-use crate::codec::dss_sp::DssSpDecoder;
-use crate::demux::ds2::{demux_ds2, DemuxedDs2};
-use crate::demux::dss::demux_dss;
 use crate::demux::{detect_format, AudioFormat};
 use crate::error::{DecodeError, Result};
 use crate::output::resample::resample;
 use crate::output::wav::write_wav;
 use crate::output::OutputConfig;
+use crate::streaming::StreamingDecoder;
 
 use std::path::Path;
 
@@ -36,85 +33,154 @@ pub fn decode_file(path: &Path) -> Result<AudioBuffer> {
 
 /// Decode raw file bytes to an AudioBuffer.
 pub fn decode_to_buffer(data: &[u8]) -> Result<AudioBuffer> {
-    let format = detect_format(data)
+    let mut decoder = StreamingDecoder::new();
+    let mut samples = decoder.push(data)?;
+    samples.extend(decoder.finish_lenient()?);
+
+    let format = decoder
+        .format()
+        .or_else(|| detect_format(data))
         .ok_or_else(|| DecodeError::UnsupportedFormat(data.first().copied().unwrap_or(0)))?;
 
-    match format {
-        AudioFormat::DssSp => decode_dss_sp(data),
-        AudioFormat::Ds2Sp => decode_ds2_sp(data),
-        AudioFormat::Ds2Qp => decode_ds2_qp(data),
-    }
-}
-
-fn decode_dss_sp(data: &[u8]) -> Result<AudioBuffer> {
-    let (packets, total_frames) = demux_dss(data)?;
-    let mut decoder = DssSpDecoder::new();
-    let mut all_samples = Vec::with_capacity(total_frames * 264);
-
-    for pkt in &packets {
-        let frame_samples = decoder.decode_frame(pkt);
-        // Convert i16 to f64
-        all_samples.extend(frame_samples.iter().map(|&s| s as f64));
-    }
-
     Ok(AudioBuffer {
-        samples: all_samples,
-        native_rate: 11025,
-        format: AudioFormat::DssSp,
+        samples,
+        native_rate: format.native_sample_rate(),
+        format,
     })
 }
 
-fn decode_ds2_sp(data: &[u8]) -> Result<AudioBuffer> {
-    let demuxed = demux_ds2(data)?;
-    match demuxed {
-        DemuxedDs2::Sp {
-            packets,
-            total_frames,
-        } => {
-            let mut decoder = Ds2SpDecoder::new();
-            let mut all_samples = Vec::with_capacity(total_frames * 288);
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codec::ds2_sp::Ds2SpDecoder;
+    use crate::codec::dss_sp::DssSpDecoder;
+    use crate::codec::ds2_qp::Ds2QpDecoder;
+    use crate::demux::ds2::{demux_ds2, DemuxedDs2};
+    use crate::demux::dss::demux_dss;
 
-            for pkt in &packets {
-                let frame_samples = decoder.decode_frame(pkt);
-                all_samples.extend_from_slice(&frame_samples);
-            }
+    fn make_truncated_ds2_qp_file(frame_count: u8) -> Vec<u8> {
+        let mut data = vec![0u8; 0x600];
+        data[..4].copy_from_slice(b"\x03ds2");
 
-            Ok(AudioBuffer {
-                samples: all_samples,
-                native_rate: 12000,
-                format: AudioFormat::Ds2Sp,
-            })
+        let mut block = [0u8; 512];
+        block[2] = frame_count;
+        block[4] = 6;
+        for (i, byte) in block[6..].iter_mut().enumerate() {
+            *byte = (i as u8).wrapping_mul(3).wrapping_add(1);
         }
-        _ => Err(DecodeError::UnsupportedFormat(6)),
+
+        data.extend_from_slice(&block);
+        data
     }
-}
 
-fn decode_ds2_qp(data: &[u8]) -> Result<AudioBuffer> {
-    let demuxed = demux_ds2(data)?;
-    match demuxed {
-        DemuxedDs2::Qp {
-            stream,
-            total_frames,
-        } => {
-            let mut decoder = Ds2QpDecoder::new();
-            let all_samples = decoder.decode_all_frames(&stream, total_frames);
+    fn make_truncated_ds2_sp_file(frame_count: u8) -> Vec<u8> {
+        let mut data = vec![0u8; 0x600];
+        data[..4].copy_from_slice(b"\x03ds2");
 
-            Ok(AudioBuffer {
-                samples: all_samples,
-                native_rate: 16000,
-                format: AudioFormat::Ds2Qp,
-            })
+        let mut block = [0u8; 512];
+        block[2] = frame_count;
+        block[4] = 0;
+        for (i, byte) in block[6..].iter_mut().enumerate() {
+            *byte = (i as u8).wrapping_mul(5).wrapping_add(7);
         }
-        _ => Err(DecodeError::UnsupportedFormat(0)),
+
+        data.extend_from_slice(&block);
+        data
+    }
+
+    fn make_truncated_dss_sp_file(frame_count: u8) -> Vec<u8> {
+        let mut data = vec![0u8; 1024];
+        data[0] = 2;
+        data[1..4].copy_from_slice(b"dss");
+
+        let mut block = [0u8; 512];
+        block[2] = frame_count;
+        for (i, byte) in block[6..].iter_mut().enumerate() {
+            *byte = (i as u8).wrapping_mul(7).wrapping_add(3);
+        }
+
+        data.extend_from_slice(&block);
+        data
+    }
+
+    #[test]
+    fn test_decode_to_buffer_keeps_legacy_lenient_tail_handling_for_ds2_qp() {
+        let data = make_truncated_ds2_qp_file(10);
+
+        let expected = match demux_ds2(&data).unwrap() {
+            DemuxedDs2::Qp {
+                stream,
+                total_frames,
+            } => {
+                let mut decoder = Ds2QpDecoder::new();
+                decoder.decode_all_frames(&stream, total_frames)
+            }
+            _ => panic!("expected DS2 QP stream"),
+        };
+
+        let decoded = decode_to_buffer(&data).unwrap();
+        let mut streaming = StreamingDecoder::new();
+        let _ = streaming.push(&data).unwrap();
+
+        assert!(matches!(streaming.finish(), Err(DecodeError::Truncated(_))));
+        assert_eq!(decoded.format, AudioFormat::Ds2Qp);
+        assert_eq!(decoded.native_rate, 16000);
+        assert_eq!(decoded.samples, expected);
+    }
+
+    #[test]
+    fn test_decode_to_buffer_keeps_legacy_lenient_tail_handling_for_ds2_sp() {
+        let data = make_truncated_ds2_sp_file(13);
+
+        let expected = match demux_ds2(&data).unwrap() {
+            DemuxedDs2::Sp { packets, .. } => {
+                let mut decoder = Ds2SpDecoder::new();
+                let mut samples = Vec::new();
+                for packet in &packets {
+                    samples.extend_from_slice(&decoder.decode_frame(packet));
+                }
+                samples
+            }
+            _ => panic!("expected DS2 SP packets"),
+        };
+
+        let decoded = decode_to_buffer(&data).unwrap();
+        let mut streaming = StreamingDecoder::new();
+        let _ = streaming.push(&data).unwrap();
+
+        assert!(matches!(streaming.finish(), Err(DecodeError::Truncated(_))));
+        assert_eq!(decoded.format, AudioFormat::Ds2Sp);
+        assert_eq!(decoded.native_rate, 12000);
+        assert_eq!(decoded.samples, expected);
+    }
+
+    #[test]
+    fn test_decode_to_buffer_keeps_legacy_lenient_tail_handling_for_dss_sp() {
+        let data = make_truncated_dss_sp_file(13);
+
+        let expected = {
+            let (packets, _) = demux_dss(&data).unwrap();
+            let mut decoder = DssSpDecoder::new();
+            let mut samples = Vec::new();
+            for packet in &packets {
+                samples.extend(decoder.decode_frame(packet).into_iter().map(|sample| sample as f64));
+            }
+            samples
+        };
+
+        let decoded = decode_to_buffer(&data).unwrap();
+        let mut streaming = StreamingDecoder::new();
+        let _ = streaming.push(&data).unwrap();
+
+        assert!(matches!(streaming.finish(), Err(DecodeError::Truncated(_))));
+        assert_eq!(decoded.format, AudioFormat::DssSp);
+        assert_eq!(decoded.native_rate, 11025);
+        assert_eq!(decoded.samples, expected);
     }
 }
 
 /// Decode a file and write to WAV with given output configuration.
-pub fn decode_and_write(
-    input: &Path,
-    output: &Path,
-    config: &OutputConfig,
-) -> Result<AudioBuffer> {
+pub fn decode_and_write(input: &Path, output: &Path, config: &OutputConfig) -> Result<AudioBuffer> {
     let mut buf = decode_file(input)?;
 
     let target_rate = config.sample_rate.unwrap_or(buf.native_rate);
@@ -123,7 +189,13 @@ pub fn decode_and_write(
         buf.samples = resample(&buf.samples, buf.native_rate, target_rate)?;
     }
 
-    write_wav(output, &buf.samples, target_rate, config.bit_depth, config.channels)?;
+    write_wav(
+        output,
+        &buf.samples,
+        target_rate,
+        config.bit_depth,
+        config.channels,
+    )?;
 
     Ok(buf)
 }

--- a/dss-codec/src/main.rs
+++ b/dss-codec/src/main.rs
@@ -1,6 +1,8 @@
 use clap::Parser;
+use dss_codec::crypto::ds2_encrypted::{parse_decrypt_descriptor, ENCRYPTED_MAGIC};
 use dss_codec::demux::detect_format;
 use dss_codec::output::OutputConfig;
+use std::env;
 use std::path::PathBuf;
 
 #[derive(Parser)]
@@ -41,6 +43,10 @@ struct Cli {
     /// Print file metadata only
     #[arg(long)]
     info: bool,
+
+    /// Password for encrypted DS2 input (or set DSS_CODEC_PASSWORD)
+    #[arg(long)]
+    password: Option<String>,
 }
 
 fn main() {
@@ -58,6 +64,7 @@ fn main() {
         bit_depth: cli.bits,
         channels: cli.channels,
     };
+    let password = resolve_password(cli.password.as_deref());
 
     for input_path in &cli.input {
         let output_path = if let Some(ref out) = cli.output_file {
@@ -74,7 +81,12 @@ fn main() {
             eprintln!("Decoding: {}", input_path.display());
         }
 
-        match dss_codec::decode_and_write(input_path, &output_path, &config) {
+        match dss_codec::decode_and_write_with_password(
+            input_path,
+            &output_path,
+            &config,
+            password.as_deref(),
+        ) {
             Ok(buf) => {
                 if !cli.quiet {
                     let duration = buf.samples.len() as f64 / buf.native_rate as f64;
@@ -96,6 +108,13 @@ fn main() {
     }
 }
 
+fn resolve_password(cli_password: Option<&str>) -> Option<Vec<u8>> {
+    cli_password
+        .map(str::as_bytes)
+        .map(|bytes| bytes.to_vec())
+        .or_else(|| env::var("DSS_CODEC_PASSWORD").ok().map(|value| value.into_bytes()))
+}
+
 fn make_output_path(input: &PathBuf, output_dir: Option<&std::path::Path>, ext: &str) -> PathBuf {
     let stem = input.file_stem().unwrap_or_default();
     let filename = format!("{}.{}", stem.to_string_lossy(), ext);
@@ -115,12 +134,56 @@ fn print_info(path: &PathBuf, _quiet: bool) {
         }
     };
 
+    if data.starts_with(&ENCRYPTED_MAGIC) {
+        match parse_decrypt_descriptor(&data) {
+            Ok(desc) => {
+                println!(
+                    "{}: encrypted DS2 ({:?}), password required",
+                    path.display(),
+                    desc.key_mode
+                );
+            }
+            Err(e) => {
+                println!("{}: encrypted DS2 (descriptor error: {})", path.display(), e);
+            }
+        }
+        return;
+    }
+
     match detect_format(&data) {
         Some(fmt) => {
             println!("{}: {:?}, native rate {} Hz", path.display(), fmt, fmt.native_sample_rate());
         }
         None => {
             println!("{}: unknown format", path.display());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_password;
+    use std::env;
+
+    #[test]
+    fn resolve_password_prefers_cli_over_env() {
+        unsafe {
+            env::set_var("DSS_CODEC_PASSWORD", "env-secret");
+        }
+        assert_eq!(resolve_password(Some("cli-secret")), Some(b"cli-secret".to_vec()));
+        unsafe {
+            env::remove_var("DSS_CODEC_PASSWORD");
+        }
+    }
+
+    #[test]
+    fn resolve_password_falls_back_to_env() {
+        unsafe {
+            env::set_var("DSS_CODEC_PASSWORD", "env-secret");
+        }
+        assert_eq!(resolve_password(None), Some(b"env-secret".to_vec()));
+        unsafe {
+            env::remove_var("DSS_CODEC_PASSWORD");
         }
     }
 }

--- a/dss-codec/src/streaming.rs
+++ b/dss-codec/src/streaming.rs
@@ -1,0 +1,290 @@
+use crate::codec::ds2_qp::Ds2QpDecoder;
+use crate::codec::ds2_sp::Ds2SpDecoder;
+use crate::codec::dss_sp::DssSpDecoder;
+use crate::demux::ds2::{Ds2QpStreamDemuxer, Ds2SpStreamDemuxer};
+use crate::demux::dss::DssSpStreamDemuxer;
+use crate::demux::{detect_format, AudioFormat};
+use crate::error::{DecodeError, Result};
+
+pub struct StreamingDecoder {
+    prebuffer: Vec<u8>,
+    format: Option<AudioFormat>,
+    demuxer: Option<ActiveDemuxer>,
+    decoder: Option<ActiveDecoder>,
+    finished: bool,
+}
+
+enum ActiveDemuxer {
+    Dss(DssSpStreamDemuxer),
+    Ds2Sp(Ds2SpStreamDemuxer),
+    Ds2Qp(Ds2QpStreamDemuxer),
+}
+
+enum ActiveDecoder {
+    Dss(DssSpDecoder),
+    Ds2Sp(Ds2SpDecoder),
+    Ds2Qp(Ds2QpDecoder),
+}
+
+impl StreamingDecoder {
+    pub fn new() -> Self {
+        Self {
+            prebuffer: Vec::new(),
+            format: None,
+            demuxer: None,
+            decoder: None,
+            finished: false,
+        }
+    }
+
+    pub fn push(&mut self, bytes: &[u8]) -> Result<Vec<f64>> {
+        if self.finished {
+            return Err(DecodeError::AlreadyFinished);
+        }
+
+        if self.format.is_none() {
+            self.prebuffer.extend_from_slice(bytes);
+            if !self.try_initialize()? {
+                return Ok(Vec::new());
+            }
+
+            let buffered = std::mem::take(&mut self.prebuffer);
+            return self.push_active(&buffered);
+        }
+
+        self.push_active(bytes)
+    }
+
+    pub fn finish(&mut self) -> Result<Vec<f64>> {
+        if self.finished {
+            return Ok(Vec::new());
+        }
+
+        if self.format.is_none() {
+            if self.prebuffer.is_empty() {
+                self.finished = true;
+                return Ok(Vec::new());
+            }
+
+            if self.try_initialize()? {
+                let buffered = std::mem::take(&mut self.prebuffer);
+                let mut samples = self.push_active(&buffered)?;
+                samples.extend(self.finish_active()?);
+                self.finished = true;
+                return Ok(samples);
+            }
+
+            return if self.prebuffer.len() >= 4 && self.prebuffer[..4] == *b"\x03ds2" {
+                Err(DecodeError::Truncated("DS2 header".to_string()))
+            } else if self.prebuffer.len() >= 4
+                && self.prebuffer[1..4] == *b"dss"
+                && (self.prebuffer[0] == 2 || self.prebuffer[0] == 3)
+            {
+                Err(DecodeError::Truncated("DSS header".to_string()))
+            } else {
+                Err(DecodeError::UnsupportedFormat(
+                    self.prebuffer.first().copied().unwrap_or(0),
+                ))
+            };
+        }
+
+        let samples = self.finish_active()?;
+        self.finished = true;
+        Ok(samples)
+    }
+
+    pub(crate) fn finish_lenient(&mut self) -> Result<Vec<f64>> {
+        if self.finished {
+            return Ok(Vec::new());
+        }
+
+        if self.format.is_none() {
+            if self.prebuffer.is_empty() {
+                self.finished = true;
+                return Ok(Vec::new());
+            }
+
+            if self.try_initialize()? {
+                let buffered = std::mem::take(&mut self.prebuffer);
+                let mut samples = self.push_active(&buffered)?;
+                samples.extend(self.finish_active_lenient()?);
+                self.finished = true;
+                return Ok(samples);
+            }
+
+            return if self.prebuffer.len() >= 4 && self.prebuffer[..4] == *b"\x03ds2" {
+                Err(DecodeError::Truncated("DS2 header".to_string()))
+            } else if self.prebuffer.len() >= 4
+                && self.prebuffer[1..4] == *b"dss"
+                && (self.prebuffer[0] == 2 || self.prebuffer[0] == 3)
+            {
+                Err(DecodeError::Truncated("DSS header".to_string()))
+            } else {
+                Err(DecodeError::UnsupportedFormat(
+                    self.prebuffer.first().copied().unwrap_or(0),
+                ))
+            };
+        }
+
+        let samples = self.finish_active_lenient()?;
+        self.finished = true;
+        Ok(samples)
+    }
+
+    pub fn format(&self) -> Option<AudioFormat> {
+        self.format
+    }
+
+    pub fn native_rate(&self) -> Option<u32> {
+        self.format.map(|fmt| fmt.native_sample_rate())
+    }
+
+    fn try_initialize(&mut self) -> Result<bool> {
+        if let Some(format) = detect_format(&self.prebuffer) {
+            self.initialize_for_format(format);
+            return Ok(true);
+        }
+
+        if self.prebuffer.len() >= 4 {
+            let is_dss_prefix = self.prebuffer[1..4] == *b"dss"
+                && (self.prebuffer[0] == 2 || self.prebuffer[0] == 3);
+            let is_ds2_prefix = self.prebuffer[..4] == *b"\x03ds2";
+            if !is_dss_prefix && !is_ds2_prefix {
+                return Err(DecodeError::UnsupportedFormat(
+                    self.prebuffer.first().copied().unwrap_or(0),
+                ));
+            }
+        }
+
+        Ok(false)
+    }
+
+    fn initialize_for_format(&mut self, format: AudioFormat) {
+        self.format = Some(format);
+        match format {
+            AudioFormat::DssSp => {
+                let version = self.prebuffer[0];
+                self.demuxer = Some(ActiveDemuxer::Dss(DssSpStreamDemuxer::new(version)));
+                self.decoder = Some(ActiveDecoder::Dss(DssSpDecoder::new()));
+            }
+            AudioFormat::Ds2Sp => {
+                self.demuxer = Some(ActiveDemuxer::Ds2Sp(Ds2SpStreamDemuxer::new()));
+                self.decoder = Some(ActiveDecoder::Ds2Sp(Ds2SpDecoder::new()));
+            }
+            AudioFormat::Ds2Qp => {
+                self.demuxer = Some(ActiveDemuxer::Ds2Qp(Ds2QpStreamDemuxer::new()));
+                self.decoder = Some(ActiveDecoder::Ds2Qp(Ds2QpDecoder::new()));
+            }
+        }
+    }
+
+    fn push_active(&mut self, bytes: &[u8]) -> Result<Vec<f64>> {
+        let frames = match self.demuxer.as_mut() {
+            Some(ActiveDemuxer::Dss(demuxer)) => demuxer.push(bytes)?,
+            Some(ActiveDemuxer::Ds2Sp(demuxer)) => demuxer.push(bytes)?,
+            Some(ActiveDemuxer::Ds2Qp(demuxer)) => demuxer.push(bytes)?,
+            None => return Ok(Vec::new()),
+        };
+
+        self.decode_frames(frames)
+    }
+
+    fn finish_active(&mut self) -> Result<Vec<f64>> {
+        let frames = match self.demuxer.as_mut() {
+            Some(ActiveDemuxer::Dss(demuxer)) => demuxer.finish()?,
+            Some(ActiveDemuxer::Ds2Sp(demuxer)) => demuxer.finish()?,
+            Some(ActiveDemuxer::Ds2Qp(demuxer)) => demuxer.finish()?,
+            None => Vec::new(),
+        };
+
+        self.decode_frames(frames)
+    }
+
+    fn finish_active_lenient(&mut self) -> Result<Vec<f64>> {
+        let frames = match self.demuxer.as_mut() {
+            Some(ActiveDemuxer::Dss(demuxer)) => demuxer.finish_lenient()?,
+            Some(ActiveDemuxer::Ds2Sp(demuxer)) => demuxer.finish_lenient()?,
+            Some(ActiveDemuxer::Ds2Qp(demuxer)) => demuxer.finish_lenient()?,
+            None => Vec::new(),
+        };
+
+        self.decode_frames(frames)
+    }
+
+    fn decode_frames(&mut self, frames: Vec<Vec<u8>>) -> Result<Vec<f64>> {
+        let mut samples = Vec::new();
+        match self.decoder.as_mut() {
+            Some(ActiveDecoder::Dss(decoder)) => {
+                for frame in frames {
+                    let frame_samples = decoder.decode_frame(&frame);
+                    samples.extend(frame_samples.into_iter().map(|sample| sample as f64));
+                }
+            }
+            Some(ActiveDecoder::Ds2Sp(decoder)) => {
+                for frame in frames {
+                    samples.extend_from_slice(&decoder.decode_frame(&frame));
+                }
+            }
+            Some(ActiveDecoder::Ds2Qp(decoder)) => {
+                for frame in frames {
+                    samples.extend_from_slice(&decoder.decode_frame(&frame));
+                }
+            }
+            None => {}
+        }
+
+        Ok(samples)
+    }
+}
+
+impl Default for StreamingDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_ds2_header_only(mode: u8) -> Vec<u8> {
+        let mut data = vec![0u8; 0x600 + 512];
+        data[..4].copy_from_slice(b"\x03ds2");
+        data[0x600 + 4] = mode;
+        data
+    }
+
+    #[test]
+    fn test_streaming_decoder_detects_only_when_enough_bytes_arrive() {
+        let data = make_ds2_header_only(6);
+        let mut decoder = StreamingDecoder::new();
+
+        let first = decoder.push(&data[..4]).unwrap();
+        assert!(first.is_empty());
+        assert_eq!(decoder.format(), None);
+        assert_eq!(decoder.native_rate(), None);
+
+        let second = decoder.push(&data[4..]).unwrap();
+        assert!(second.is_empty());
+        assert_eq!(decoder.format(), Some(AudioFormat::Ds2Qp));
+        assert_eq!(decoder.native_rate(), Some(16000));
+    }
+
+    #[test]
+    fn test_streaming_decoder_truncated_header_on_finish() {
+        let mut decoder = StreamingDecoder::new();
+        let _ = decoder.push(b"\x03ds2").unwrap();
+
+        let err = decoder.finish().unwrap_err();
+        assert!(matches!(err, DecodeError::Truncated(_)));
+    }
+
+    #[test]
+    fn test_streaming_decoder_push_after_finish_errors() {
+        let mut decoder = StreamingDecoder::new();
+        let _ = decoder.finish().unwrap();
+
+        let err = decoder.push(b"\x03ds2").unwrap_err();
+        assert!(matches!(err, DecodeError::AlreadyFinished));
+    }
+}


### PR DESCRIPTION
This pull request adds support for decoding password-protected (encrypted) DS2 files.

In my tests, results identical byte-to-byte output compared with DssDecoder.dll. 
Both 128bit and 256bit encryption are supported. 
