### PR TITLE
Expose file inspection API

### DIFF
--- a/dss-codec/src/demux/mod.rs
+++ b/dss-codec/src/demux/mod.rs
@@ -64,6 +64,14 @@ pub fn detect_format(data: &[u8]) -> Option<AudioFormat> {
     if data[1..4] == *b"dss" && (data[0] == 2 || data[0] == 3) {
         return Some(AudioFormat::DssSp);
     }
+    if data[..4] == *b"\x03enc" && data.len() > 0x604 {
+        let format_type = data[0x600 + 4];
+        return Some(match format_type {
+            7 => AudioFormat::Ds2Qp7,
+            6 => AudioFormat::Ds2Qp,
+            _ => AudioFormat::Ds2Sp,
+        });
+    }
     if matches!(&data[..4], b"\x03ds2" | b"\x01ds2" | b"\x07ds2") && data.len() > 0x604 {
         let header_size = detect_ds2_audio_start(data);
         if data.len() <= header_size + 4 {
@@ -77,4 +85,34 @@ pub fn detect_format(data: &[u8]) -> Option<AudioFormat> {
         });
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_ds2_like_file(magic: [u8; 4], mode: u8) -> Vec<u8> {
+        let mut data = vec![0u8; 0x600 + 0x200];
+        data[..4].copy_from_slice(&magic);
+        data[0x600 + 4] = mode;
+        data
+    }
+
+    #[test]
+    fn detect_format_recognizes_encrypted_ds2_qp() {
+        let data = make_ds2_like_file(*b"\x03enc", 6);
+        assert_eq!(detect_format(&data), Some(AudioFormat::Ds2Qp));
+    }
+
+    #[test]
+    fn detect_format_recognizes_encrypted_ds2_qp7() {
+        let data = make_ds2_like_file(*b"\x03enc", 7);
+        assert_eq!(detect_format(&data), Some(AudioFormat::Ds2Qp7));
+    }
+
+    #[test]
+    fn detect_format_recognizes_encrypted_ds2_sp() {
+        let data = make_ds2_like_file(*b"\x03enc", 0);
+        assert_eq!(detect_format(&data), Some(AudioFormat::Ds2Sp));
+    }
 }

--- a/dss-codec/src/lib.rs
+++ b/dss-codec/src/lib.rs
@@ -7,6 +7,7 @@ pub mod output;
 pub mod streaming;
 pub mod tables;
 
+use crate::crypto::ds2_encrypted::ENCRYPTED_MAGIC;
 use crate::demux::{detect_format, AudioFormat};
 use crate::error::{DecodeError, Result};
 use crate::output::resample::resample;
@@ -24,6 +25,30 @@ pub struct AudioBuffer {
     pub native_rate: u32,
     /// Detected format
     pub format: AudioFormat,
+}
+
+/// Lightweight file/container inspection result.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FileInfo {
+    /// Detected audio format.
+    pub format: AudioFormat,
+    /// Encryption metadata for the container.
+    pub encryption: EncryptionInfo,
+}
+
+impl FileInfo {
+    pub fn native_rate(&self) -> u32 {
+        self.format.native_sample_rate()
+    }
+}
+
+/// Encryption metadata detected from the file/container header.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EncryptionInfo {
+    None,
+    EncryptedDs2Aes128,
+    EncryptedDs2Aes256,
+    EncryptedUnknown(u16),
 }
 
 /// Normalize a DSS/DS2 file to plain container bytes.
@@ -44,6 +69,36 @@ pub fn decrypt_to_bytes(data: &[u8], password: Option<&[u8]>) -> Result<Vec<u8>>
     let mut plain = decryptor.push(data)?;
     plain.extend(decryptor.finish()?);
     Ok(plain)
+}
+
+/// Inspect a DSS/DS2 file and report format/encryption metadata.
+pub fn inspect_file(path: &Path) -> Result<FileInfo> {
+    let data = std::fs::read(path)?;
+    inspect_bytes(&data)
+}
+
+/// Inspect raw DSS/DS2 bytes and report format/encryption metadata.
+pub fn inspect_bytes(data: &[u8]) -> Result<FileInfo> {
+    let format = detect_format(data)
+        .ok_or_else(|| DecodeError::UnsupportedFormat(data.first().copied().unwrap_or(0)))?;
+
+    let encryption = if data.starts_with(&ENCRYPTED_MAGIC) {
+        let mode_offset = crate::crypto::ds2_encrypted::DECRYPT_DESCRIPTOR_OFFSET;
+        let mode = data
+            .get(mode_offset..mode_offset + 2)
+            .map(|bytes| u16::from_le_bytes([bytes[0], bytes[1]]))
+            .ok_or_else(|| DecodeError::EncryptedDs2("missing decrypt descriptor".to_string()))?;
+
+        match mode {
+            1 => EncryptionInfo::EncryptedDs2Aes128,
+            2 => EncryptionInfo::EncryptedDs2Aes256,
+            other => EncryptionInfo::EncryptedUnknown(other),
+        }
+    } else {
+        EncryptionInfo::None
+    };
+
+    Ok(FileInfo { format, encryption })
 }
 
 /// Decode a DSS/DS2 file to an AudioBuffer.
@@ -131,4 +186,41 @@ pub fn decode_and_write_with_password(
     )?;
 
     Ok(buf)
+}
+
+#[cfg(test)]
+mod inspection_tests {
+    use super::*;
+    use crate::crypto::ds2_encrypted::DECRYPT_DESCRIPTOR_OFFSET;
+
+    fn encrypted_ds2(mode: u16, format_type: u8) -> Vec<u8> {
+        let mut data = vec![0u8; 0x800];
+        data[..4].copy_from_slice(&ENCRYPTED_MAGIC);
+        data[DECRYPT_DESCRIPTOR_OFFSET..DECRYPT_DESCRIPTOR_OFFSET + 2]
+            .copy_from_slice(&mode.to_le_bytes());
+        data[0x604] = format_type;
+        data
+    }
+
+    #[test]
+    fn inspect_bytes_reports_encryption_and_format() {
+        assert_eq!(
+            inspect_bytes(&encrypted_ds2(1, 6)).unwrap(),
+            FileInfo {
+                format: AudioFormat::Ds2Qp,
+                encryption: EncryptionInfo::EncryptedDs2Aes128,
+            }
+        );
+        assert_eq!(
+            inspect_bytes(&encrypted_ds2(2, 7)).unwrap(),
+            FileInfo {
+                format: AudioFormat::Ds2Qp7,
+                encryption: EncryptionInfo::EncryptedDs2Aes256,
+            }
+        );
+        assert_eq!(
+            inspect_bytes(&encrypted_ds2(99, 0)).unwrap().encryption,
+            EncryptionInfo::EncryptedUnknown(99)
+        );
+    }
 }

--- a/dss-codec/src/main.rs
+++ b/dss-codec/src/main.rs
@@ -1,7 +1,6 @@
 use clap::Parser;
-use dss_codec::crypto::ds2_encrypted::{parse_decrypt_descriptor, ENCRYPTED_MAGIC};
-use dss_codec::demux::detect_format;
 use dss_codec::output::OutputConfig;
+use dss_codec::EncryptionInfo;
 use std::env;
 use std::path::PathBuf;
 
@@ -178,42 +177,35 @@ fn make_decrypt_output_path(input: &PathBuf, output_dir: Option<&std::path::Path
 }
 
 fn print_info(path: &PathBuf, _quiet: bool) {
-    let data = match std::fs::read(path) {
-        Ok(d) => d,
-        Err(e) => {
-            eprintln!("Error reading {}: {}", path.display(), e);
-            return;
-        }
-    };
-
-    if data.starts_with(&ENCRYPTED_MAGIC) {
-        match parse_decrypt_descriptor(&data) {
-            Ok(desc) => {
-                println!(
-                    "{}: encrypted DS2 ({:?}), password required",
-                    path.display(),
-                    desc.key_mode
-                );
-            }
-            Err(e) => {
-                println!("{}: encrypted DS2 (descriptor error: {})", path.display(), e);
-            }
-        }
-        return;
-    }
-
-    match detect_format(&data) {
-        Some(fmt) => {
-            println!(
+    match dss_codec::inspect_file(path) {
+        Ok(info) => match info.encryption {
+            EncryptionInfo::None => println!(
                 "{}: {:?}, native rate {} Hz",
                 path.display(),
-                fmt,
-                fmt.native_sample_rate()
-            );
+                info.format,
+                info.native_rate()
+            ),
+            EncryptionInfo::EncryptedDs2Aes128 => println!(
+                "{}: encrypted DS2 (AES-128), native rate {} Hz, password required",
+                path.display(),
+                info.native_rate()
+            ),
+            EncryptionInfo::EncryptedDs2Aes256 => println!(
+                "{}: encrypted DS2 (AES-256), native rate {} Hz, password required",
+                path.display(),
+                info.native_rate()
+            ),
+            EncryptionInfo::EncryptedUnknown(mode) => println!(
+                "{}: encrypted container (mode 0x{:04x}), native rate {} Hz",
+                path.display(),
+                mode,
+                info.native_rate()
+            ),
+        },
+        Err(dss_codec::error::DecodeError::Io(e)) => {
+            eprintln!("Error reading {}: {}", path.display(), e);
         }
-        None => {
-            println!("{}: unknown format", path.display());
-        }
+        Err(e) => println!("{}: info unavailable ({})", path.display(), e),
     }
 }
 


### PR DESCRIPTION
This change is not mandatory, but is useful to maintaining the python (https://github.com/[gaspardpetit/pydsscodec](https://github.com/gaspardpetit/pydsscodec)) and web assembly (https://github.com/[gaspardpetit/dss-codec-wasm](https://github.com/gaspardpetit/dss-codec-wasm)) ports. 

## Summary

Expose DSS/DS2 file inspection as a reusable public library API and refactor the existing CLI `--info` implementation to use it.

## Description

Applications currently need to duplicate container-header parsing to identify:

- The detected DSS/DS2 codec and native sample rate.
- Whether a DS2 file is encrypted.
- Whether it uses AES-128, AES-256, or an unknown encryption mode.

The new `inspect_file()` and `inspect_bytes()` functions provide this metadata without decoding audio or requiring a password. This is useful for file browsers, upload validation, transcription pipelines, Python/WASM bindings, and applications that need to request a password before decoding.

## Changes

- Add public `FileInfo` and `EncryptionInfo` types.
- Add `inspect_file()` and `inspect_bytes()`.
- Recognize encrypted DS2 SP, QP, and QP7 containers during format detection.
- Refactor CLI `--info` to use the public API.
- Add tests covering AES-128, AES-256, unknown encryption modes, and encrypted SP/QP/QP7 detection.

No decoding or decryption behavior is changed.